### PR TITLE
Comcat exceptions

### DIFF
--- a/src/scratch/aftershockStatistics/ComcatAccessor.java
+++ b/src/scratch/aftershockStatistics/ComcatAccessor.java
@@ -56,10 +56,10 @@ public class ComcatAccessor {
 		List<JsonEvent> events;
 		try {
 			events = service.getEvents(query);
-        } catch (FileNotFoundException e) {
+		} catch (FileNotFoundException e) {
 			// If ComCat does not recognize the eventID, ComCat returns HTTP error 404, which appears here as FileNotFoundException.
 			return null;
-        } catch (IOException e) {
+		} catch (IOException e) {
 			// If the eventID has been deleted from ComCat, ComCat returns HTTP error 409, which appears here as IOException.
 			return null;
 		} catch (Exception e) {

--- a/src/scratch/aftershockStatistics/ComcatAccessor.java
+++ b/src/scratch/aftershockStatistics/ComcatAccessor.java
@@ -28,6 +28,9 @@ import org.opensha.sha.earthquake.observedEarthquake.ObsEqkRupture;
 
 import com.google.common.base.Preconditions;
 
+import java.io.IOException;
+import java.io.FileNotFoundException;
+
 public class ComcatAccessor {
 	
 	private static final boolean D = true;
@@ -53,6 +56,12 @@ public class ComcatAccessor {
 		List<JsonEvent> events;
 		try {
 			events = service.getEvents(query);
+        } catch (FileNotFoundException e) {
+			// If ComCat does not recognize the eventID, ComCat returns HTTP error 404, which appears here as FileNotFoundException.
+			return null;
+        } catch (IOException e) {
+			// If the eventID has been deleted from ComCat, ComCat returns HTTP error 409, which appears here as IOException.
+			return null;
 		} catch (Exception e) {
 			throw ExceptionUtils.asRuntimeException(e);
 		}
@@ -152,17 +161,25 @@ public class ComcatAccessor {
 			try {
 				events = service.getEvents(query);
 				count = events.size();
-				System.out.println(count);
+			} catch (FileNotFoundException e) {
+				events = null;
+				count = 0;
+			} catch (IOException e) {
+				events = null;
+				count = 0;
 			} catch (Exception e) {
 				throw ExceptionUtils.asRuntimeException(e);
 			}
 
+			System.out.println(count);
 
-			for (JsonEvent event : events) {
-				boolean wrap = mainshockLonWrapped && event.getLongitude().doubleValue() < 0;
-				ObsEqkRupture rup = eventToObsRup(event, wrap);
-				if (rup !=null)
-					rups.add(rup);
+			if (count > 0) {
+				for (JsonEvent event : events) {
+					boolean wrap = mainshockLonWrapped && event.getLongitude().doubleValue() < 0;
+					ObsEqkRupture rup = eventToObsRup(event, wrap);
+					if (rup !=null)
+						rups.add(rup);
+				}
 			}
 			rups.sortByOriginTime();
 			if(count==0)


### PR DESCRIPTION
Add exception handlers for calls to ComCat.

ComCat generates HTTP errors when it cannot find the event you're looking for.  These trigger exceptions in the Java code, which were not being handled.  I added handlers to catch these exceptions, and treat the exceptions the same as if ComCat had returned an empty set of results.

Note:  I only modified the ComcatAccessor class in scratch.aftershockStatistics.  There is another very similar ComcatAccessor class in scratch.aftershockStatisticsETAS.  It should receive the same changes.  I have not modified the other one because I am not set up to test scratch.aftershockStatisticsETAS.  If you wish, I can modify the other ComcatAccessor and then you can test it.  Note that the other ComcatAccessor also doesn't have the fix for the longitude wrap-around at 180 degrees.