### PR TITLE
RJ model revision

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     compileOnly 'com.fasterxml.jackson.core:jackson-annotations:2.8.11'
     compileOnly 'com.fasterxml.jackson.core:jackson-core:2.8.11'
     compileOnly 'com.fasterxml.jackson.core:jackson-databind:2.8.11'
-    compileOnly 'org.mongodb:mongo-java-driver:3.6.2'
+    compileOnly 'org.mongodb:mongo-java-driver:3.6.3'
     compileOnly 'org.mongodb.morphia:morphia:1.3.2'
  
     /* no remote repo */

--- a/src/scratch/aftershockStatistics/AftershockStatsCalc.java
+++ b/src/scratch/aftershockStatistics/AftershockStatsCalc.java
@@ -12,9 +12,11 @@ import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.StringTokenizer;
+import java.util.Arrays;
 
 import org.apache.commons.math3.analysis.UnivariateFunction;
 import org.apache.commons.math3.distribution.PoissonDistribution;
+import org.apache.commons.math3.distribution.UniformRealDistribution;
 import org.jfree.data.Range;
 import org.opensha.commons.data.function.EvenlyDiscretizedFunc;
 import org.opensha.commons.data.function.HistogramFunction;
@@ -48,25 +50,67 @@ public class AftershockStatsCalc {
 	public final static double MILLISEC_PER_YEAR = 1000*60*60*24*365.25;
 	public final static long MILLISEC_PER_DAY = 1000*60*60*24;
 
+
+
+
+	/**
+	 * Compute the function value (x^z - y^z)/z
+	 * This function is designed to avoid numerical cancellation when z is small,
+	 * and deliver a correct result when z is zero.
+	 * Requires: x > 0 and y > 0.
+	 *
+	 * Implementation: The function uses the identity
+	 *  (x^z - y^z)/z == (2/z)*(sqrt(x*y)^z)*sinh(z*log(sqrt(x/y)))
+	 * It also uses the fact that if abs(v) < 1.0e-8 then sinh(v) equals v to numerical precision.
+	 */
+	public static double pow_diff_div (double x, double y, double z) {
+		if (!( x > 0.0 && y > 0.0 )) {
+			throw new RuntimeException("AftershockStatsCalc.pow_diff_div: Parameters x and y are not positive");
+		}
+		double sqrt_x = Math.sqrt(x);
+		double sqrt_y = Math.sqrt(y);
+		double u = Math.log(sqrt_x / sqrt_y);
+		double v = z * u;
+		if (Math.abs(v) < 1.0e-8) {
+			return 2.0 * Math.pow(sqrt_x * sqrt_y, z) * u;
+		}
+		return 2.0 * Math.pow(sqrt_x * sqrt_y, z) * Math.sinh(v) / z;
+	}
+
+
+
 	
 	/**
 	 * This computes the log-likelihood for the given modified Omori parameters according to 
 	 * equation (6) of Ogata (1983; J. Phys. Earth, 31,115-124).
-	 * @param k
-	 * @param p
-	 * @param c
+	 * @param k = Omori k-parameter (amplitude).
+	 * @param p = Omori p-parameter (exponent).
+	 * @param c = Omori c-parameter (time offset), in days.
 	 * @param tMinDays - the start time of of the catalog in days from main shock
 	 * @param tMaxDays - the end time of of the catalog in days from main shock
-	 * @param relativeEventTimes - in order of occurrence relative to main shock
+	 * @param relativeEventTimes - in order of occurrence relative to main shock,
+	 *        this is an array whose i-th element is the time the i-th aftershock
+	 *        occurred, measured in days since the mainshock.
 	 * @return
+	 * The return value is log(L(k,p)), where L(k,p) is the likelihood of the parameter
+	 * values k and p, taking c to be fixed.
+	 *  log(L(k,p)) = SUM(log(lambda(t_i))) - INTEGRAL(lambda(t)*dt)
+	 * where
+	 *  t_i = Time of the i-th aftershock, in days since the mainshock.
+	 *  lamda(t) = k*((t + c)^(-p))     [Omori formula]
+	 *  SUM runs over the all the aftershocks.
+	 *  INTEGRAL runs over times t = tMinDays to t = tMaxDays.
 	 */
 	public static double getLogLikelihoodForOmoriParams(double k, double p, double c, double tMinDays, double tMaxDays, double[] relativeEventTimes) {
 		double funcA=Double.NaN;
 		int n=relativeEventTimes.length;
-		if(p == 1)
-			funcA = Math.log(tMaxDays+c) - Math.log(tMinDays+c);
-		else
-			funcA = (Math.pow(tMaxDays+c,1-p) - Math.pow(tMinDays+c,1-p)) / (1-p);
+
+//		if(p == 1)
+//			funcA = Math.log(tMaxDays+c) - Math.log(tMinDays+c);
+//		else
+//			funcA = (Math.pow(tMaxDays+c,1-p) - Math.pow(tMinDays+c,1-p)) / (1-p);
+		funcA = pow_diff_div (tMaxDays+c, tMinDays+c, 1.0 - p);
+
 		double sumLn_t = 0;
 		for(double t : relativeEventTimes)
 			sumLn_t += Math.log(t+c);
@@ -76,23 +120,28 @@ public class AftershockStatsCalc {
 	}
 	
 	
+
 	
 	/**
 	 * This computes the maximum likelihood k values for constrained 
 	 * values of p and c as given.
-	 * @param p
-	 * @param c
+	 * @param p = Omori p-parameter (exponent).
+	 * @param c = Omori c-parameter (time offset), in days.
 	 * @param tMinDays - the start time of of the catalog in days from main shock
 	 * @param tMaxDays - the end time of of the catalog in days from main shock
 	 * @param numEvents - the number of events in the catalog
 	 * @return
+	 * The return value is the maximum-likelihood value of k, for given Omori parameters
+	 * p and c which are taken to be fixed, and for a given number of aftershocks.
 	 */
 	public static double getMaxLikelihood_k(double p, double c, double tMinDays, double tMaxDays, int numEvents) {
 		double funcA=Double.NaN;
-		if(p == 1)
-			funcA = Math.log(tMaxDays+c) - Math.log(tMinDays+c);
-		else
-			funcA = (Math.pow(tMaxDays+c,1-p) - Math.pow(tMinDays+c,1-p)) / (1-p);
+
+//		if(p == 1)
+//			funcA = Math.log(tMaxDays+c) - Math.log(tMinDays+c);
+//		else
+//			funcA = (Math.pow(tMaxDays+c,1-p) - Math.pow(tMinDays+c,1-p)) / (1-p);
+		funcA = pow_diff_div (tMaxDays+c, tMinDays+c, 1.0 - p);
 		
 // System.out.println("getMaxLikelihood_k: \t"+p+"\t"+c+"\t"+tMinDays+"\t"+tMaxDays+"\t"+funcA+"\t"+numEvents+"\t"+(numEvents/funcA));
 		return (double)numEvents/funcA;
@@ -103,105 +152,206 @@ public class AftershockStatsCalc {
 	
 	/**
 	 * This converts the productivity value from "a" to "k"
-	 * @param a
-	 * @param b
-	 * @param magMain
-	 * @param magMin
-	 * @return
+	 * @param a = Reasenberg-Jones productivity parameter.
+	 * @param b = Gutenberg-Richter b-parameter.
+	 * @param magMain = Magnitude of mainshock.
+	 * @param magMin = Minimum magnitude of aftershocks to consider.
+	 * @return k = Omori k-parameter (amplitude).
+	 *  k = 10^(a + b*(magMain - magMin))
 	 */
 	public static double convertProductivityTo_k(double a, double b, double magMain, double magMin) {
 		return Math.pow(10.0, a+b*(magMain-magMin));
 	}
+
+
+
 	
 	/**
 	 * This converts the productivity value from "k" to "a"
-	 * @param k
-	 * @param b
-	 * @param magMain
-	 * @param magMin
-	 * @return
+	 * @param k = Omori k-parameter (amplitude).
+	 * @param b = Gutenberg-Richter b-parameter.
+	 * @param magMain = Magnitude of mainshock.
+	 * @param magMin = Minimum magnitude of aftershocks to consider.
+	 * @return a = Reasenberg-Jones productivity parameter.
+	 *  k = 10^(a + b*(magMain - magMin))
 	 */
 	public static double convertProductivityTo_a(double k, double b, double magMain, double magMin) {
 		return Math.log10(k) - b*(magMain-magMin);
 	}
 
+
+
+
 	/**
 	 * This returns the Reasenberg Jones (1989, 1994) expected number of primary aftershocks 
-	 * between time tMin and tMax (days) for 
-	 * the given arguments.
-	 * @param a
-	 * @param b
-	 * @param magMain
-	 * @param magMin
-	 * @param p 
-	 * @param c - days
-	 * @param tMin - beginning of forecast time window (since origin time), in days
-	 * @param tMax - end of forecast time window (since origin time), in days
+	 * between time tMinDays and tMaxDays (days after the mainshock) for  the given arguments.
+	 * @param a = Reasenberg-Jones productivity parameter.
+	 * @param b = Gutenberg-Richter b-parameter.
+	 * @param magMain = Magnitude of mainshock.
+	 * @param magMin = Minimum magnitude of aftershocks to consider.
+	 * @param p = Omori p-parameter (exponent).
+	 * @param c = Omori c-parameter (time offset), in days.
+	 * @param tMinDays = Beginning of forecast time window (since origin time), in days.
+	 * @param tMaxDays = End of forecast time window (since origin time), in days.
 	 * @return
+	 * According to R&J, the rate of aftershocks of magnitude >= magMin is
+	 *  lambda(t) = k * (t + c)^(-p)
+	 * where
+	 *  k = 10^(a + b*(magMain - magMin))
+	 * The value returned by this function is the integral of lambda(t) from t=tMinDays to t=tMaxDays.
 	 */
 	public static double getExpectedNumEvents(double a, double b, double magMain, double magMin, double p, double c, double tMinDays, double tMaxDays) {
 		double k = convertProductivityTo_k(a, b, magMain, magMin);
-		if(p!=1) {
-			double oneMinusP= 1-p;
-			return (k/oneMinusP)*(Math.pow(c+tMaxDays,oneMinusP) - Math.pow(c+tMinDays,oneMinusP));
-		}
-		else {
-			return k*(Math.log(c+tMaxDays) - Math.log(c+tMinDays));
-		}
+
+//		if(p!=1) {
+//			double oneMinusP= 1-p;
+//			return (k/oneMinusP)*(Math.pow(c+tMaxDays,oneMinusP) - Math.pow(c+tMinDays,oneMinusP));
+//		}
+//		else {
+//			return k*(Math.log(c+tMaxDays) - Math.log(c+tMinDays));
+//		}
+
+		return k * pow_diff_div (c+tMaxDays, c+tMinDays, 1.0 - p);
 	}
+
+
+
+
+	/**
+	 * This returns the Reasenberg Jones (1989, 1994) rate of expected number of primary aftershocks 
+	 * at time tDays (days after the mainshock) for the given arguments.
+	 * @param a = Reasenberg-Jones productivity parameter.
+	 * @param b = Gutenberg-Richter b-parameter.
+	 * @param magMain = Magnitude of mainshock.
+	 * @param magMin = Minimum magnitude of aftershocks to consider.
+	 * @param p = Omori p-parameter (exponent).
+	 * @param c = Omori c-parameter (time offset), in days.
+	 * @param tDays = Time (since origin time), in days.
+	 * @return
+	 * According to R&J, the rate of aftershocks of magnitude >= magMin is
+	 *  lambda(t) = k * (t + c)^(-p)
+	 * where
+	 *  k = 10^(a + b*(magMain - magMin))
+	 * The value returned by this function is lambda(t) at t=tDays.
+	 */
+	public static double getExpectedEventsRate(double a, double b, double magMain, double magMin, double p, double c, double tDays) {
+		double k = convertProductivityTo_k(a, b, magMain, magMin);
+		return k * Math.pow(c+tDays, -p);
+	}
+
 	
 	
 	
 	/**
 	 * This returns the expected number of primary aftershocks as a function of time
 	 * 
-	 * @param a
-	 * @param b
-	 * @param magMain
-	 * @param magMin
-	 * @param p
-	 * @param c
-	 * @param tMin
-	 * @param tMax
-	 * @param tDelta
+	 * @param a = Reasenberg-Jones productivity parameter.
+	 * @param b = Gutenberg-Richter b-parameter.
+	 * @param magMain = Magnitude of mainshock.
+	 * @param magMin = Minimum magnitude of aftershocks to consider.
+	 * @param p = Omori p-parameter (exponent).
+	 * @param c = Omori c-parameter (time offset), in days.
+	 * @param tMin = Start of time range, in days after the mainshock.
+	 * @param tMax = End of time range, in days after the mainshock.
+	 * @param tDelta = Spacing between time values in the returned function.
 	 * @return
+	 * Returns a discrete function with:
+	 *  x = Time (in days after mainshock).
+	 *  y = Expected number of aftershocks within the corresponding time interval.
+	 * The range [tMin, tMax] is partitioned into equal-sized intervals, with the
+	 * width of each interval equal to approximately tDelta.  The interval width is
+	 * adjusted so that a whole number of intervals fit within the range [tMin, tMax].
+	 * For each such interval, the x value is the midpoint of the interval (and so
+	 * the first and last x values are tMin+x_delta/2 and tMax-x_delta/2,
+	 * where x_delta is the adjusted interval width).  The y value is the expected
+	 * number of aftershocks within that interval according to the R&J formula.
 	 */
 	public static  EvenlyDiscretizedFunc getExpectedNumWithTimeFunc(double a, double b, double magMain, double magMin, double p, double c,  double tMin, double tMax, double tDelta) {
-		EvenlyDiscretizedFunc func = new EvenlyDiscretizedFunc(tMin+tDelta/2, tMax-tDelta/2, (int)Math.round((tMax-tMin)/tDelta));
+		
+		// Get the function spacing
+
+		int num = Math.max((int)Math.round((tMax-tMin)/tDelta), 1);
+		double x_delta = (tMax-tMin)/num;
+		double x_min;
+		double x_max;
+		if (num == 1) {
+			x_min = (tMin + tMax)*0.5;
+			x_max = x_min;	// x_max and x_min must be precisely equal for num==1, otherwise EvenlyDiscretizedFunc throws an exception
+		} else {
+			x_min = tMin+x_delta/2;
+			x_max = tMax-x_delta/2;
+		}
+
+		// Construct the function
+		
+		EvenlyDiscretizedFunc func = new EvenlyDiscretizedFunc(x_min, x_max, num);
 		for(int i=0;i<func.size();i++) {
-			double binTmin = func.getX(i) - tDelta/2;
-			double binTmax = func.getX(i) + tDelta/2;
+			double binTmin = func.getX(i) - x_delta/2;
+			double binTmax = func.getX(i) + x_delta/2;
 			double yVal = getExpectedNumEvents(a, b, magMain, magMin, p, c, binTmin, binTmax);
 			func.set(i,yVal);
 		}
-		func.setName("Expected Number of Primary Aftershocks for "+tDelta+"-day intervals");
+
+		// Insert info
+
+		func.setName("Expected Number of Primary Aftershocks for "+x_delta+"-day intervals");
 		func.setInfo("for a="+a+", b="+b+", p="+p+", c="+c+", magMain="+magMain+", magMin="+magMin);
 		return func;
 	}
 	
 	
 	/**
+	 * This returns the expected cumulative number of primary aftershocks as a function of time
 	 * 
-	 * @param a
-	 * @param b
-	 * @param magMain
-	 * @param magMin
-	 * @param p
-	 * @param c
-	 * @param tMin
-	 * @param tMax
-	 * @param tDelta
+	 * @param a = Reasenberg-Jones productivity parameter.
+	 * @param b = Gutenberg-Richter b-parameter.
+	 * @param magMain = Magnitude of mainshock.
+	 * @param magMin = Minimum magnitude of aftershocks to consider.
+	 * @param p = Omori p-parameter (exponent).
+	 * @param c = Omori c-parameter (time offset).
+	 * @param tMin = Start of time range, in days after the mainshock.
+	 * @param tMax = End of time range, in days after the mainshock.
+	 * @param tDelta = Spacing between time values in the returned function.
 	 * @return
+	 * Returns a discrete function with:
+	 *  x = Time (in days after mainshock).
+	 *  y = Cumulative expected number of aftershocks for the corresponding time interval.
+	 * The range [tMin, tMax] is partitioned into equal-sized intervals, with the
+	 * width of each interval equal to approximately tDelta.  The interval width is
+	 * adjusted so that a whole number of intervals fit within the range [tMin, tMax].
+	 * For each such interval, the x value is the midpoint of the interval (and so
+	 * the first and last x values are tMin+x_delta/2 and tMax-x_delta/2,
+	 * where x_delta is the adjusted interval width).  The y value is the expected
+	 * number of aftershocks within that interval plus all preceding intervals according
+	 * to the R&J formula.
 	 */
 	public static  EvenlyDiscretizedFunc getExpectedCumulativeNumWithTimeFunc(double a, double b, double magMain, double magMin, double p, double c,  double tMin, double tMax, double tDelta) {
-		EvenlyDiscretizedFunc cumFunc = new EvenlyDiscretizedFunc(tMin+tDelta/2, tMax-tDelta/2, (int)Math.round((tMax-tMin)/tDelta));
-		EvenlyDiscretizedFunc numWithTimeFunc = getExpectedNumWithTimeFunc(a, b, magMain, magMin, p, c,  tMin, tMax, tDelta);
-		double sum = 0;
-		for(int i=0;i<cumFunc.size();i++) {
-			sum += numWithTimeFunc.getY(i);
-			cumFunc.set(i,sum);
+		
+		// Get the function spacing
+
+		int num = Math.max((int)Math.round((tMax-tMin)/tDelta), 1);
+		double x_delta = (tMax-tMin)/num;
+		double x_min;
+		double x_max;
+		if (num == 1) {
+			x_min = (tMin + tMax)*0.5;
+			x_max = x_min;	// x_max and x_min must be precisely equal for num==1, otherwise EvenlyDiscretizedFunc throws an exception
+		} else {
+			x_min = tMin+x_delta/2;
+			x_max = tMax-x_delta/2;
 		}
-		return cumFunc;
+
+		// Construct the function
+		
+		EvenlyDiscretizedFunc func = new EvenlyDiscretizedFunc(x_min, x_max, num);
+		for(int i=0;i<func.size();i++) {
+			double binTmin = func.getX(0) - x_delta/2;		// this line is the only change from getExpectedNumWithTimeFunc
+			double binTmax = func.getX(i) + x_delta/2;
+			double yVal = getExpectedNumEvents(a, b, magMain, magMin, p, c, binTmin, binTmax);
+			func.set(i,yVal);
+		}
+
+		return func;
 	}
 
 
@@ -215,6 +365,9 @@ public class AftershockStatsCalc {
 	public static double getPoissonProbability(double expectedNum) {
 		return 1.0-Math.exp(-expectedNum);
 	}
+
+
+
 	
 	/**
 	 * This returns the maximum-likelihood b-value defined by Aki (1965, Bull. Earthq. Res. Inst., 43, 237-239)
@@ -237,12 +390,18 @@ public class AftershockStatsCalc {
 		magMean /= (double)num;
 		return getMaxLikelihood_b_value(magMean, magComplete, magPrecision);
 	}
+
+
+
 	
 	/**
 	 * This does not check for negative values
 	 * @param mainShock
 	 * @param aftershockList
 	 * @return
+	 * Given a mainshock and a list of aftershocks, this function returns an array
+	 * whose i-th element contains the elapsed time from the mainshock to the i-th
+	 * aftershock, in days.
 	 */
 	public static double[] getDaysSinceMainShockArray(ObsEqkRupture mainShock, ObsEqkRupList aftershockList) {
 		double[] relativeEventTimesDays = new double[aftershockList.size()];
@@ -252,6 +411,9 @@ public class AftershockStatsCalc {
 		}
 		return relativeEventTimesDays;
 	}
+
+
+
 	
 	/**
 	 * This returns the maximum-likelihood b-value defined by Aki (1965, Bull. Earthq. Res. Inst., 43, 237-239)
@@ -262,6 +424,412 @@ public class AftershockStatsCalc {
 	 */
 	public static double getMaxLikelihood_b_value(double magMean, double magComplete, double magPrecision) {
 		return Math.log10(Math.E) /(magMean - (magComplete-0.5*magPrecision));
+	}
+
+
+
+
+	/**
+	 * This returns the Page et al. (2016) time-dependent magnitude of completeness 
+	 * at time tDays (days after the mainshock) for the given arguments.
+	 * @param magMain = Magnitude of mainshock.
+	 * @param magCat = Magnitude of completeness when there has not been a mainshock.
+	 * @param capG = The "G" parameter in the time-dependent magnitude of completeness model. 
+	 *               As a special case, if capG == 10.0 then the return value is always magCat.
+	 * @param capH = The "H" parameter in the time-dependent magnitude of completeness model.
+	 * @param tDays = Time (since origin time), in days.
+	 * @return
+	 * According to Page et al. the magnitude of completeness is
+	 *  magMin(t) = Max(magMain/2 - G - H*log10(t), magCat)
+	 * where t is in days.
+	 * This formula reflects the fact that in the aftermath of a mainshock, the catalog's
+	 * magnitude of completeness temporarily increases, and then gradually returns to normal.
+	 * The value returned by this function is magMin(t) at t=tDays.
+	 * Note: The magnitude of completeness is the minimum magnitude at which the catalog contains
+	 * essentially all earthquakes (which Page et al. defines as 95% of earthquakes).
+	 */
+	public static double getPageMagCompleteness(double magMain, double magCat, double capG, double capH, double tDays) {
+		if (capG > 9.999) {
+			return magCat;
+		}
+		return Math.max (magCat, 0.5 * magMain - capG - capH * Math.log10 (Math.max (tDays, Double.MIN_NORMAL)));
+	}
+
+
+
+
+	/**
+	 * This returns the Page et al. (2016) time of completeness, in days since the mainshock.
+	 * @param magMain = Magnitude of mainshock.
+	 * @param magCat = Magnitude of completeness when there has not been a mainshock.
+	 * @param capG = The "G" parameter in the time-dependent magnitude of completeness model. 
+	 *               As a special case, if capG == 10.0 then the return value is always magCat.
+	 * @param capH = The "H" parameter in the time-dependent magnitude of completeness model.
+	 * @return
+	 * This function returns the time (in days since the mainshock) at which the
+	 * magnitude of completness equals the catalog's normal magnitude of completeness.
+	 * According to Page et al. the magnitude of completeness is
+	 *  magMin(t) = Max(magMain/2 - G - H*log10(t), magCat)
+	 * where t is in days.
+	 * This function returns the value of t at which magMin(t) == magCat, which is
+	 *  t = 10^((magMain/2 - G - magCat)/H)
+	 * However this must be evaluated carefully to avoid overflow or divide-by-zero.
+	 */
+	public static double getPageTimeOfCompleteness(double magMain, double magCat, double capG, double capH) {
+		if (capG > 9.999) {
+			return 0.0;
+		}
+
+		if (!( capH >= 0.0 )) {
+			throw new RuntimeException("AftershockStatsCalc.getPageTimeOfCompleteness: H parameter is negative");
+		}
+
+		double x = 0.5 * magMain - capG - magCat;
+
+		if (x <= -8.0 * capH) {
+			return 0.0;			// less than about 1 millisecond, just return 0
+		}
+		if (x >= 12.0 * capH) {
+			return 1.0e12;		// more than about 3 billion years
+		}
+
+		return Math.pow(10.0, x/capH);
+	}
+
+
+
+
+	/**
+	 * This returns the Reasenberg Jones (1989, 1994) rate of expected number of primary aftershocks 
+	 * at time tDays (days after the mainshock) for the given arguments,
+	 * with the Page et al. (2016) time-dependent magnitude of completeness.
+	 * @param a = Reasenberg-Jones productivity parameter.
+	 * @param b = Gutenberg-Richter b-parameter.
+	 * @param magMain = Magnitude of mainshock.
+	 * @param magCat = Magnitude of completeness when there has not been a mainshock.
+	 * @param capG = The "G" parameter in the time-dependent magnitude of completeness model. 
+	 *               As a special case, if capG == 10.0 then the return value is always magCat.
+	 * @param capH = The "H" parameter in the time-dependent magnitude of completeness model.
+	 * @param p = Omori p-parameter (exponent).
+	 * @param c = Omori c-parameter (time offset), in days.
+	 * @param tDays = Time (since origin time), in days.
+	 * @return
+	 * According to R&J, the rate of aftershocks of magnitude >= magMin is
+	 *  lambda(t) = k * (t + c)^(-p)
+	 * where
+	 *  k = 10^(a + b*(magMain - magMin))
+	 * According to Page et al. the magnitude of completeness is
+	 *  magMin(t) = Max(magMain/2 - G - H*log10(t), magCat)
+	 * In these formulas, t is measured in days.
+	 * The value returned by this function is lambda(t) at t=tDays.
+	 */
+	public static double getPageExpectedEventsRate(double a, double b, double magMain, double magCat, double capG, double capH, double p, double c, double tDays) {
+		double magMin = getPageMagCompleteness(magMain, magCat, capG, capH, tDays);
+		return getExpectedEventsRate(a, b, magMain, magMin, p, c, tDays);
+	}
+
+
+
+
+	/**
+	 * This returns the Reasenberg Jones (1989, 1994) expected number of primary aftershocks 
+	 * between time tMinDays and tMaxDays (days after the mainshock) for the given arguments,
+	 * with the Page et al. (2016) time-dependent magnitude of completeness.
+	 * @param a = Reasenberg-Jones productivity parameter.
+	 * @param b = Gutenberg-Richter b-parameter.
+	 * @param magMain = Magnitude of mainshock.
+	 * @param magCat = Magnitude of completeness when there has not been a mainshock.
+	 * @param capG = The "G" parameter in the time-dependent magnitude of completeness model. 
+	 *               As a special case, if capG == 10.0 then the return value is always magCat.
+	 * @param capH = The "H" parameter in the time-dependent magnitude of completeness model.
+	 * @param p = Omori p-parameter (exponent).
+	 * @param c = Omori c-parameter (time offset), in days.
+	 * @param tMinDays = Beginning of forecast time window (since origin time), in days.
+	 * @param tMaxDays = End of forecast time window (since origin time), in days.
+	 * @return
+	 * According to R&J, the rate of aftershocks of magnitude >= magMin is
+	 *  lambda(t) = k * (t + c)^(-p)
+	 * where
+	 *  k = 10^(a + b*(magMain - magMin))
+	 * According to Page et al. the magnitude of completeness is
+	 *  magMin(t) = Max(magMain/2 - G - H*log10(t), magCat)
+	 * In these formulas, t is measured in days.
+	 * The value returned by this function is the integral of lambda(t) from t=tMinDays to t=tMaxDays.
+	 *
+	 * Implementation note: This function uses numerical integration for times t < tPage,
+	 * and an analytic formula for times t > tPage, where tPage is the time when the
+	 * magnitude of completeness first becomes equal to magCat.  Aside from the gain in
+	 * efficiency, it is necessary to break the domain of integration into two parts because
+	 * the rate function is non-differentiable at t = tPage.
+	 *
+	 * Note: It is possible to force the use of numeric integration for an RJ distribution
+	 * with constant magMin by choosing parameters so that:
+	 *  magMain/2 - G == magMin
+	 *  H == 0
+	 *  magCat < magMin
+	 * This is useful for testing the numeric integration code, by comparing to the analytic formula.
+	 */
+	public static double getPageExpectedNumEvents(double a, double b, double magMain, double magCat, double capG, double capH, double p, double c, double tMinDays, double tMaxDays) {
+		
+		// Transition time, when magnitude of completeness first becomes equal to magCat
+
+		double tPage = getPageTimeOfCompleteness(magMain, magCat, capG, capH);
+		
+		// Integral value
+
+		double s = 0.0;
+
+		// Numeric integration for times before tPage
+
+		if (tPage > tMinDays) {
+
+			// Set up functional object
+		
+			funcExpectedEventsRate func = new funcExpectedEventsRate (a, b, magMain, magCat, capG, capH, p, c);
+
+			// Upper limit of integration
+
+			double tUpper = Math.min(tMaxDays, tPage);
+
+			// Force at least 30 points to be sampled, but don't force steps smaller than about 1 second
+
+			double max_h = Math.max(1.0e-5, (tUpper - tMinDays) / 30.0);
+
+			// Error tolerances
+
+			double abs_tol = 0.0;
+			double rel_tol = 1.0e-7;
+
+			// Do the integration
+
+			s += adapQuadSimpson (func, tMinDays, tUpper, abs_tol, rel_tol, max_h);
+		}
+
+		// Analytic formula for times after tPage
+
+		if (tPage < tMaxDays) {
+			s += getExpectedNumEvents(a, b, magMain, magCat, p, c, Math.max(tMinDays, tPage), tMaxDays);
+		}
+
+		return s;
+	}
+
+
+
+
+	/**
+	 * This produces a randomly-generated simulated aftershock sequence, following the
+	 * Reasenberg-Jones (1989, 1994) statistics formula, with the Page et al. (2016)
+	 * time-dependent magnitude of completeness.
+	 * @param a = Reasenberg-Jones productivity parameter.
+	 * @param b = Gutenberg-Richter b-parameter.
+	 * @param magMain = Magnitude of mainshock.
+	 * @param magCat = Magnitude of completeness when there has not been a mainshock.
+	 * @param capG = The "G" parameter in the time-dependent magnitude of completeness model. 
+	 *               As a special case, if capG == 10.0 then the magnitude of completeness is always magCat.
+	 * @param capH = The "H" parameter in the time-dependent magnitude of completeness model.
+	 * @param p = Omori p-parameter (exponent).
+	 * @param c = Omori c-parameter (time offset), in days.
+	 * @param tMinDays = Beginning of time span (since origin time), in days.
+	 * @param tMaxDays = End of time span (since origin time), in days.
+	 * @return
+	 * Returns a randomly-generated sequence of aftershocks.
+	 * Each entry in the returned list contains a time (in milliseconds since the mainshock)
+	 * and magnitude; no other information is placed in the list.
+	 *
+	 * Implementation notes:
+	 * The given time span is paritioned into intervals where there is about 3 expected aftershock
+	 * (according to the R&J formula, with a lower bound for time-dependent magnitude of completeness).
+	 * In each interval, a Poisson distribution is used to randomly select the number of aftershocks.
+	 * Then, a rejection sampling technique is used to randomly select a time within the interval
+	 * for each aftershock, according to the R&J density function.
+	 * Then, an exponential distribution is used to randomly select a magnitude for each aftershock.
+	 * Then, any aftershocks below the time-dependent magnitude of completeness are discarded.
+	 *
+	 * The documentation for UniformRealDistribution is here:
+	 * http://commons.apache.org/proper/commons-math/javadocs/api-3.6/org/apache/commons/math3/distribution/UniformRealDistribution.html
+	 * The algorithm used for generating the Poisson distribution is the first algorithm given here:
+	 * https://en.wikipedia.org/wiki/Poisson_distribution
+	 * The algorithm used for generating the exponential distribution is given here:
+	 * https://en.wikipedia.org/wiki/Exponential_distribution
+	 */
+	public static ObsEqkRupList simAftershockSequence(double a, double b, double magMain, double magCat, double capG, double capH, double p, double c, double tMinDays, double tMaxDays) {
+		if (!( b > 0.0 )) {
+			throw new RuntimeException("AftershockStatsCalc.simAftershockSequence: b parameter is negative or zero");
+		}
+		if (!( capH >= 0.0 )) {
+			throw new RuntimeException("AftershockStatsCalc.simAftershockSequence: H parameter is negative");
+		}
+		if (!( p > 0.0 )) {
+			throw new RuntimeException("AftershockStatsCalc.simAftershockSequence: p parameter is negative or zero");
+		}
+		if (!( c >= 0.0 )) {
+			throw new RuntimeException("AftershockStatsCalc.simAftershockSequence: c parameter is negative");
+		}
+		if (!( tMinDays + c > 0.0 && tMinDays < tMaxDays )) {
+			throw new RuntimeException("AftershockStatsCalc.simAftershockSequence: invalid time span");
+		}
+
+		// Maximum number of aftershocks per interval that we allow
+
+		final int max_aftershocks = 100;
+
+		// Array to hold the time for each aftershock within an interval
+
+		double[] t_aftershock = new double[max_aftershocks];
+
+		// Random number generator, produces random numbers between 0.0 (inclusive) and 1.0 (exclusive)
+
+		UniformRealDistribution rangen = new UniformRealDistribution();
+
+		// The list of aftershocks
+
+		ObsEqkRupList aftershock_list = new ObsEqkRupList();
+
+		// The minimum magnitude we need to consider is the magnitude of completeness at the end of the time span,
+		// which is a lower bound for magnitude of completeness throughout the time span
+
+		double magMin = getPageMagCompleteness(magMain, magCat, capG, capH, tMaxDays);
+
+		// The start time of the current interval, in days
+
+		double t_now = tMinDays;
+
+		// Flag used to control interval generation
+
+		boolean f_continue = true;			// true if there are more intervals to do
+
+		// Loop until all intervals are done
+
+		while (f_continue) {
+
+			// The current aftershock rate is an upper bound for aftershock rate in the interval
+
+			double rate_now = getExpectedEventsRate(a, b, magMain, magMin, p, c, t_now);
+
+			// Get the approximate time interval in which 3 aftershocks are expected
+			// (this is an upper bound because the rate is decreasing)
+
+			double t_delta = 3.0 / rate_now;
+
+			// If it extends past the end of the time span, clip to end of time span and make it the last interval
+
+			if (t_now + t_delta >= tMaxDays) {
+				t_delta = tMaxDays - t_now;
+				f_continue = false;
+			}
+
+			// If it extends almost to the end of the time span, go halfway to the end
+
+			else if (t_now + t_delta*1.5 >= tMaxDays) {
+				t_delta = (tMaxDays - t_now) * 0.5;
+			}
+
+			// The minimum magnitude we need to consider is the magnitude of completeness at the end of the interval,
+			// which is a lower bound for magnitude of completeness throughout the interval
+
+			double magMinInt = getPageMagCompleteness(magMain, magCat, capG, capH, t_now + t_delta);
+
+			// Get the expected number of aftershocks in the interval from t_now to t_now + t_delta
+
+			double expected_aftershocks = getExpectedNumEvents(a, b, magMain, magMinInt, p, c, t_now, t_now + t_delta);
+
+			// If the expected number of aftershocks is less than 0.75, double the interval until it's larger
+
+			if (f_continue) {
+				while (expected_aftershocks < 0.75 && t_now + t_delta*4.0 < tMaxDays) {
+					double new_t_delta = t_delta * 2.0;
+					double new_magMinInt = getPageMagCompleteness(magMain, magCat, capG, capH, t_now + new_t_delta);
+					double new_expected_aftershocks = getExpectedNumEvents(a, b, magMain, new_magMinInt, p, c, t_now, t_now + new_t_delta);
+
+					if (new_expected_aftershocks > 3.0) {
+						break;
+					}
+
+					t_delta = new_t_delta;
+					magMinInt = new_magMinInt;
+					expected_aftershocks = new_expected_aftershocks;
+				}
+			}
+
+			// Apply the Poisson distribution to select the actual number of aftershocks
+
+			int actual_aftershocks = -1;
+			double pd_l = Math.exp (-expected_aftershocks);
+			double pd_p = 1.0;
+
+			do {
+				++actual_aftershocks;
+				pd_p *= rangen.sample();
+			} while (pd_p > pd_l && actual_aftershocks < max_aftershocks - 1);
+
+			// If there are aftershocks in this interval ...
+
+			if (actual_aftershocks > 0) {
+
+				// The current aftershock rate is an upper bound for aftershock rate in the interval
+
+				double rate_ub = getExpectedEventsRate(a, b, magMain, magMinInt, p, c, t_now);
+
+				// Loop over aftershocks within this interval
+
+				for (int i = 0; i < actual_aftershocks; ++i) {
+
+					// Use rejection sampling technique to select a time for this aftershock.
+					// This works by sampling points uniformly in the rectangle t_now <= t <= t_now + t_delta
+					// and 0 <= h <= rate_ub, then rejecting those that lie above the R&J probability density.
+
+					double t;
+					double h;
+					double r;
+
+					do {
+						t = t_now + t_delta * rangen.sample();
+						h = rate_ub * rangen.sample();
+						r = getExpectedEventsRate(a, b, magMain, magMinInt, p, c, t);
+					} while (h > r);
+
+					t_aftershock[i] = t;
+				}
+
+				// Sort the aftershocks into temporal order
+
+				Arrays.sort (t_aftershock, 0, actual_aftershocks);
+
+				// Loop over aftershocks within this interval
+
+				for (int i = 0; i < actual_aftershocks; ++i) {
+
+					// Time of this aftershock
+
+					double t = t_aftershock[i];
+
+					// Use the exponential distribution to get the magnitude
+
+					double u = 1.0 - rangen.sample();
+					double mag = magMinInt - Math.log10(Math.max(u, Double.MIN_NORMAL)) / b;
+
+					// If the magnitude is at least the magnitude of completeness ...
+
+					if (mag >= getPageMagCompleteness(magMain, magCat, capG, capH, t)) {
+					
+						// Add the aftershock to the list
+
+						double timeMillis = t*((double)MILLISEC_PER_DAY);
+						int eventId = aftershock_list.size() + 1;
+						aftershock_list.add(new ObsEqkRupture(Integer.toString(eventId), (long)timeMillis, null, mag));
+					}
+				}
+			}
+
+			// Advance to next time interval
+
+			t_now += t_delta;
+		}
+
+		// Return the resulting list of aftershocks
+
+		return aftershock_list;
 	}
 	
 	
@@ -423,32 +991,201 @@ public class AftershockStatsCalc {
 		System.out.println("Mmaxc="+(float)mmaxc+" from MFD mode(s): "+Joiner.on(",").join(magsAtMax));
 		return mmaxc;
 	}
+
+
+
+
+
+	/**
+	 * Functional object to calculate R&J aftershock rate with time-dependent magnitude of completeness.
+	 * This object stores all its parameters.
+	 * Then, a call to the value(t) function returns the aftershock rate at time t (days since the mainshock).
+	 * @param a = Reasenberg-Jones productivity parameter.
+	 * @param b = Gutenberg-Richter b-parameter.
+	 * @param magMain = Magnitude of mainshock.
+	 * @param magCat = Magnitude of completeness when there has not been a mainshock.
+	 * @param capG = The "G" parameter in the time-dependent magnitude of completeness model. 
+	 *               As a special case, if capG == 10.0 then the magnitude of completeness is always magCat.
+	 * @param capH = The "H" parameter in the time-dependent magnitude of completeness model.
+	 * @param p = Omori p-parameter (exponent).
+	 * @param c = Omori c-parameter (time offset), in days.
+	 *
+	 * The documentation for UnivariateFunction is here:
+	 * http://commons.apache.org/proper/commons-math/javadocs/api-3.6/org/apache/commons/math3/analysis/UnivariateFunction.html
+	 */
+	public static class funcExpectedEventsRate implements UnivariateFunction {
+
+		// Parameters for R&J and magnitude of completeness
+
+		public double a;
+		public double b;
+		public double magMain;
+		public double magCat;
+		public double capG;
+		public double capH;
+		public double p;
+		public double c;
+
+		// Constructor saves all the parameters.
+
+		public funcExpectedEventsRate (double a, double b, double magMain, double magCat, double capG, double capH, double p, double c) {
+			this.a = a;
+			this.b = b;
+			this.magMain = magMain;
+			this.magCat = magCat;
+			this.capG = capG;
+			this.capH = capH;
+			this.p = p;
+			this.c = c;
+		}
+
+		// Get the aftershock rate at time tDays (in days since the mainshock).
+
+		@Override
+		public double value(double tDays) {
+			return AftershockStatsCalc.getPageExpectedEventsRate(a, b, magMain, magCat, capG, capH, p, c, tDays);
+		}
+	}
+
+
+
 	
-	   /**
-	    *  adaptive quadrature integration.  This is put here because it is not clear how general/robust this code is
-	    *  (e.g., with respect to singularities in the function).
-	    *  
-	    *  TODO In fact, this should be tested over the viable range of rate-decay functions that could be given
-	    * @param func
-	    * @param startTime
-	    * @param endTime
-	    * @return
-	    */
-    public static double adaptiveQuadratureIntegration(RJ_AftershockModel_SequenceSpecific func, double startTime, double endTime) {
-    	final double EPSILON = 1e-6;
-    	double a=startTime;
-    	double b=endTime;
-        double h = b - a;
-        double c = (a + b) / 2.0;
-        double d = (a + c) / 2.0;
-        double e = (b + c) / 2.0;
-        double Q1 = h/6  * (func.getRateAboveMagCompleteAtTime(a) + 4*func.getRateAboveMagCompleteAtTime(c) + func.getRateAboveMagCompleteAtTime(b));
-        double Q2 = h/12 * (func.getRateAboveMagCompleteAtTime(a) + 4*func.getRateAboveMagCompleteAtTime(d) + 2*func.getRateAboveMagCompleteAtTime(c) + 4*func.getRateAboveMagCompleteAtTime(e) + func.getRateAboveMagCompleteAtTime(b));
-        if (Math.abs(Q2 - Q1) <= EPSILON)
-            return Q2 + (Q2 - Q1) / 15;
-        else
-            return adaptiveQuadratureIntegration(func,a, c) + adaptiveQuadratureIntegration(func,c, b);
-    }
+	/**
+	 * Recursive subroutine for adaptive quadrature using Simpson's rule.
+	 * This implements a 5-point Simpson's rule at equally spaced points x0,x1,x2,x3,x4.
+	 * It estimates error by comparing to the 3-point rule for x0,x2,x4.
+	 * If error exceeds tolerance, it calls itself recursively for the two subintervals.
+	 * @param func = Function being integrated.
+	 * @param x0 = Abscissa 0.
+	 * @param x4 = Abscissa 4.
+	 * @param f0 = Function value for x0.
+	 * @param f2 = Function value for x2.
+	 * @param f4 = Function value for x4.
+	 * @param abs_tol = Absolute error tolerance (must be >= 0.0).
+	 * @param rel_tol = Relative error tolerance (must be >= 0.0).
+	 * @param min_level = Minimum level of recursion before accepting results (must be <= max_level).
+	 * @param max_level = Maximum allowed level of recursion.
+	 * @return
+	 * Returns the integral of the function from x0 to x4.
+	 */
+	private static double adapQuadSimpsonRecur (UnivariateFunction func,
+			double x0, double x4, double f0, double f2, double f4,
+			double abs_tol, double rel_tol, int min_level, int max_level) {
+
+		// Get the function values for x1 and x3
+
+		double x2 = (x0 + x4) * 0.5;
+		double x1 = (x0 + x2) * 0.5;
+		double x3 = (x2 + x4) * 0.5;
+
+		double f1 = func.value(x1);
+		double f3 = func.value(x3);
+
+		// If satisfies minimum level ...
+
+		if (min_level <= 0) {
+
+			// Calculate the 3-point and 5-point Simpson's rules
+
+			double h = x4 - x0;
+
+			double s3pt = (f0 + 4.0*f2 + f4) * h/6.0;
+			double s5pt = (f0 + 4.0*f1 + 2.0*f2 + 4.0*f3 + f4) * h/12.0;
+
+			double sdelta = s5pt - s3pt;
+
+			// If we're at maximum level, return the result
+
+			if (max_level <= 0) {
+				return s5pt + (sdelta / 15.0);
+			}
+
+			// Estimate the magnitude of the integral
+
+			double smag = (Math.abs(f0) + 4.0*Math.abs(f1) + 2.0*Math.abs(f2) + 4.0*Math.abs(f3) + Math.abs(f4)) * h/12.0;
+
+			// If error criterion is satisfied, return the result
+
+			if (Math.abs(sdelta) <= 15.0 * (Math.max(abs_tol, rel_tol*smag) + Double.MIN_NORMAL)) {
+				return s5pt + (sdelta / 15.0);
+			}
+		}
+
+		// Recursive invocation
+
+		return adapQuadSimpsonRecur (func, x0, x2, f0, f1, f2, abs_tol * 0.5, rel_tol, min_level - 1, max_level - 1)
+		     + adapQuadSimpsonRecur (func, x2, x4, f2, f3, f4, abs_tol * 0.5, rel_tol, min_level - 1, max_level - 1);
+	}
+
+
+
+	
+	/**
+	 * Adaptive quadrature using Simpson's rule.
+	 * Calculate the integral of the function from a to b.
+	 * @param func = Function being integrated.
+	 * @param a = Lower limit of range of integration.
+	 * @param b = Upper limit of range of integration.
+	 * @param abs_tol = Absolute error tolerance.
+	 *   Attempt to make the absolute error less that abs_tol.
+	 * @param rel_tol = Relative error tolerance.
+	 *   Attempt to make the relative error less than rel_tol.
+	 *   If rel_tol and abs_tol are both nonzero then the more lenient one is used.
+	 * @param max_h = Maximum h for subintervals (h = length of subinterval) .
+	 *   This can be used to ensure that sufficient samples are taken.
+	 *   It is not an error for max_h to be larger than b - a.
+	 *   As a special case, max_h == 0 means there is no maximum.
+	 * @return
+	 * Returns the integral of the function from a to b.
+	 */
+	private static double adapQuadSimpson (UnivariateFunction func,
+			double a, double b, double abs_tol, double rel_tol, double max_h) {
+
+		// Check for zero length interval
+
+		double h = b - a;
+
+		if (Math.abs(h) <= Double.MIN_NORMAL) {
+			return 0.0;
+		}
+
+		// Get the initial function values
+
+		double x2 = (a + b) * 0.5;
+
+		double f0 = func.value(a);
+		double f2 = func.value(x2);
+		double f4 = func.value(b);
+
+		// Choose a maximum level to retain about 20 significant bits in h (2.10e6 ~ 2^21, 8.59e9 ~ 2^33)
+
+		double min_h = Math.max(Double.MIN_NORMAL * 2.10e6, Math.max(Math.abs(a), Math.abs(b)) / 8.59e9);
+
+		int max_level = 0;
+		double trial_h = Math.abs(b - a) * 0.5;
+		while (max_level < 28 && trial_h > min_h) {
+			++max_level;
+			trial_h *= 0.5;
+		}
+
+		// Choose a minimum level with sufficient samples
+
+		int min_level = 0;
+		if (Math.abs(max_h) > Double.MIN_NORMAL) {
+			trial_h = Math.abs(b - a) * 0.25;
+			while (min_level < max_level && trial_h > Math.abs(max_h)) {
+				++min_level;
+				trial_h *= 0.5;
+			}
+		}
+
+		// Invoke recursive adaptive routine
+
+		return adapQuadSimpsonRecur (func, a, b, f0, f2, f4, Math.abs(abs_tol), Math.abs(rel_tol), min_level, max_level);
+	}
+
+
+	
 
     public static Location getCentroid(ObsEqkRupture mainshock, ObsEqkRupList aftershocks) {
 		// now works across prime meridian
@@ -478,61 +1215,281 @@ public class AftershockStatsCalc {
 		return centroid;
 	}
 
+
+
+
 	/**
 	 * @param args
 	 */
 	public static void main(String[] args) {
-		
-//		double mean = 0.78;
-		double mean = 11.5079;
-		
-		PoissonDistribution poissDist = new PoissonDistribution(mean);
-		System.out.println(poissDist.inverseCumulativeProbability(0.025));
-		System.out.println(poissDist.inverseCumulativeProbability(0.975));
-		
-		int minInt=0;
-		int maxInt=poissDist.inverseCumulativeProbability(0.999);
-		
-		HistogramFunction hist = new HistogramFunction((double)minInt,(double)maxInt,maxInt+1);
-		HistogramFunction histCum = new HistogramFunction((double)minInt,(double)maxInt,maxInt+1);
-		for(int i=0;i<hist.size();i++) {
-			hist.set(i, poissDist.probability(i));
-			histCum.set(i, poissDist.cumulativeProbability(i));
-		}
-		
-		int lowBound = (int)Math.round(histCum.getClosestXtoY(0.025));
-		if(histCum.getY(lowBound)<0.025)
-			lowBound += 1;
-		
-		int highBound = (int)Math.round(histCum.getClosestXtoY(0.975));
-		if(histCum.getY(highBound)<0.975)
-			highBound += 1;
-		
-		System.out.println(lowBound);
-		System.out.println(highBound);
-		
-		ArrayList<HistogramFunction> funcList = new ArrayList<HistogramFunction>();
-		funcList.add(hist);
-		funcList.add(histCum);
-		
-		ArrayList<PlotCurveCharacterstics> plotCharList = new ArrayList<PlotCurveCharacterstics>();
-		plotCharList.add(new PlotCurveCharacterstics(PlotLineType.HISTOGRAM, 2f, Color.BLACK));
-		plotCharList.add(new PlotCurveCharacterstics(PlotLineType.SOLID, 2f, Color.BLUE));
-		
-		GraphWindow graph = new GraphWindow(funcList, "Poisson Distributions",plotCharList); 
-		graph.setX_AxisLabel("Num");
-		graph.setY_AxisLabel("Probability");
 
+		// There needs to be at least one argument, which is the subcommand
+
+		if (args.length < 1) {
+			System.err.println ("AftershockStatsCalc : Missing subcommand");
+			return;
+		}
+
+		// Subcommand : Test #1
+		// Command format:
+		//  test1
+		// This is the pre-existing test for the class.
+
+		if (args[0].equalsIgnoreCase ("test1")) {
+
+			// No additional arguments
+
+			if (args.length != 1) {
+				System.err.println ("AftershockStatsCalc : Invalid 'test1' subcommand");
+				return;
+			}
+
+			// Run the test
 		
+//			double mean = 0.78;
+			double mean = 11.5079;
 		
-//		System.out.println(getExpectedNumEvents(0d, 1d, 1d, 1d, 1.025, 0.05, 0d, 1e6));
+			PoissonDistribution poissDist = new PoissonDistribution(mean);
+			System.out.println(poissDist.inverseCumulativeProbability(0.025));
+			System.out.println(poissDist.inverseCumulativeProbability(0.975));
 		
-//		double val = Math.log(Double.MAX_VALUE);
-//		System.out.println(val);
-//		System.out.println(Math.exp(700.0));
+			int minInt=0;
+			int maxInt=poissDist.inverseCumulativeProbability(0.999);
 		
-//		testJeanneCalc();
-//		testAndyCalc();
+			HistogramFunction hist = new HistogramFunction((double)minInt,(double)maxInt,maxInt+1);
+			HistogramFunction histCum = new HistogramFunction((double)minInt,(double)maxInt,maxInt+1);
+			for(int i=0;i<hist.size();i++) {
+				hist.set(i, poissDist.probability(i));
+				histCum.set(i, poissDist.cumulativeProbability(i));
+			}
+		
+			int lowBound = (int)Math.round(histCum.getClosestXtoY(0.025));
+			if(histCum.getY(lowBound)<0.025)
+				lowBound += 1;
+		
+			int highBound = (int)Math.round(histCum.getClosestXtoY(0.975));
+			if(histCum.getY(highBound)<0.975)
+				highBound += 1;
+		
+			System.out.println(lowBound);
+			System.out.println(highBound);
+		
+			ArrayList<HistogramFunction> funcList = new ArrayList<HistogramFunction>();
+			funcList.add(hist);
+			funcList.add(histCum);
+		
+			ArrayList<PlotCurveCharacterstics> plotCharList = new ArrayList<PlotCurveCharacterstics>();
+			plotCharList.add(new PlotCurveCharacterstics(PlotLineType.HISTOGRAM, 2f, Color.BLACK));
+			plotCharList.add(new PlotCurveCharacterstics(PlotLineType.SOLID, 2f, Color.BLUE));
+		
+			GraphWindow graph = new GraphWindow(funcList, "Poisson Distributions",plotCharList); 
+			graph.setX_AxisLabel("Num");
+			graph.setY_AxisLabel("Probability");
+		
+//			System.out.println(getExpectedNumEvents(0d, 1d, 1d, 1d, 1.025, 0.05, 0d, 1e6));
+		
+//			double val = Math.log(Double.MAX_VALUE);
+//			System.out.println(val);
+//			System.out.println(Math.exp(700.0));
+		
+//			testJeanneCalc();
+//			testAndyCalc();
+
+			return;
+		}
+
+		// Subcommand : Test #2
+		// Command format:
+		//  test2
+		// Test the implementation of getExpectedNumEvents using pow_diff_div
+		// by comparing to the old way.
+
+		if (args[0].equalsIgnoreCase ("test2")) {
+
+			// No additional arguments
+
+			if (args.length != 1) {
+				System.err.println ("AftershockStatsCalc : Invalid 'test2' subcommand");
+				return;
+			}
+
+			// Construct a list of p values
+
+			ArrayList<Double> pList = new ArrayList<Double>();
+
+			pList.add(0.9);
+			pList.add(0.99);
+			pList.add(0.999);
+			pList.add(0.9999);
+			pList.add(0.99999);
+			pList.add(0.999999);
+			pList.add(0.9999999);
+			pList.add(1.0);
+			pList.add(1.0000001);
+			pList.add(1.000001);
+			pList.add(1.00001);
+			pList.add(1.0001);
+			pList.add(1.001);
+			pList.add(1.01);
+			pList.add(1.1);
+
+			// Other parameter values
+			
+			double a = -1.67;
+			double b = 0.91;
+			double c = 0.05;
+			double magMain = 7.5;
+			double magMin = 2.5;
+			double tMinDays = 10.0;
+			double tMaxDays = 11.0;
+
+			// Calculate results for each p
+
+			for (Double pd : pList) {
+				double p = pd;
+
+				// New value
+
+				double newVal = getExpectedNumEvents(a, b, magMain, magMin, p, c, tMinDays, tMaxDays);
+
+				// Old value
+
+				double oldVal;
+				double k = convertProductivityTo_k(a, b, magMain, magMin);
+
+				if(p!=1) {
+					double oneMinusP= 1-p;
+					oldVal = (k/oneMinusP)*(Math.pow(c+tMaxDays,oneMinusP) - Math.pow(c+tMinDays,oneMinusP));
+				}
+				else {
+					oldVal = k*(Math.log(c+tMaxDays) - Math.log(c+tMinDays));
+				}
+
+				// Display results
+
+				System.out.println (String.format ("%.7f  %.15e  %.15e", p, newVal, oldVal));
+			}
+
+			return;
+		}
+
+		// Subcommand : Test #3
+		// Command format:
+		//  test3
+		// Test the implementation of simAftershockSequence by producing a simulated
+		// aftershock with Jeanne's parameters for 0 to 30 days.
+		// The resulting list of (magnitude, time in days) is written to standard output.
+		// There should be about 3000 aftershocks.
+
+		if (args[0].equalsIgnoreCase ("test3")) {
+
+			// No additional arguments
+
+			if (args.length != 1) {
+				System.err.println ("AftershockStatsCalc : Invalid 'test3' subcommand");
+				return;
+			}
+
+			// Parameter values
+			
+			double a = -1.67;
+			double b = 0.91;
+			double c = 0.05;
+			double p = 1.08;
+			double magMain = 7.5;
+			double magCat = 2.5;
+//			double capG = 4.5;
+			double capH = 0.75;
+			double tMinDays = 0.0;
+			double tMaxDays = 30.0;
+
+			// The completeness parameters don't match Jeanne's simulation data, here is my best guess
+			// (note this value yields a time of completeness of exactly 1 day)
+
+			double capG = 1.25;
+
+			// Run the simulation
+
+			ObsEqkRupList aftershock_list = simAftershockSequence(a, b, magMain, magCat, capG, capH, p, c, tMinDays, tMaxDays);
+
+			// Output the number of aftershocks
+					
+			System.out.println (String.format ("Generated %d aftershocks", aftershock_list.size()));
+
+			// Output the results, but stop at 10,000
+
+			for (int i = 0; i < aftershock_list.size(); ++i) {
+				if (i == 10000) {
+					System.out.println (String.format ("... plus %d more aftershocks", aftershock_list.size() - i));
+					break;
+				}
+				ObsEqkRupture rupture = aftershock_list.get(i);
+				double mag = rupture.getMag();
+				double tDays = ((double)(rupture.getOriginTime())) / ((double)MILLISEC_PER_DAY);
+				System.out.println (String.format ("%.2f  %.8f", mag, tDays));
+			}
+
+			return;
+		}
+
+		// Subcommand : Test #4
+		// Command format:
+		//  test4
+		// Test the numeric integration code.
+
+		if (args[0].equalsIgnoreCase ("test4")) {
+
+			// No additional arguments
+
+			if (args.length != 1) {
+				System.err.println ("AftershockStatsCalc : Invalid 'test4' subcommand");
+				return;
+			}
+
+			// Parameter values
+			
+			double a = -1.67;
+			double b = 0.91;
+			double c = 0.05;
+			double p = 1.08;
+			double magMain = 7.5;
+			double magCat = 2.5;
+			double capG = 1.25;
+			double capH = 0.75;
+			double tMinDays = 0.0;
+			double tMaxDays = 30.0;
+
+			// R&J, direct calculation
+
+			double rj_direct = getExpectedNumEvents(a, b, magMain, magCat, p, c, tMinDays, tMaxDays);
+
+			// R&J, analytic
+
+			double rj_analytic = getPageExpectedNumEvents(a, b, magMain, magCat, 10.0, 0.0, p, c, tMinDays, tMaxDays);
+
+			// R&J, numeric
+
+			double rj_numeric = getPageExpectedNumEvents(a, b, magMain, 1.00, 1.25, 0.0, p, c, tMinDays, tMaxDays);
+
+			// R&J, page completeness
+
+			double rj_page = getPageExpectedNumEvents(a, b, magMain, magCat, capG, capH, p, c, tMinDays, tMaxDays);
+
+			// Output the results
+					
+			System.out.println (String.format ("rj_direct   = %.15e", rj_direct));
+			System.out.println (String.format ("rj_analytic = %.15e", rj_analytic));
+			System.out.println (String.format ("rj_numeric  = %.15e", rj_numeric));
+			System.out.println (String.format ("rj_page     = %.15e", rj_page));
+
+			return;
+		}
+
+		// Unrecognized subcommand.
+
+		System.err.println ("AftershockStatsCalc : Unrecognized subcommand : " + args[0]);
+		return;
+
 	}
 
 }

--- a/src/scratch/aftershockStatistics/GenericRJ_Parameters.java
+++ b/src/scratch/aftershockStatistics/GenericRJ_Parameters.java
@@ -12,13 +12,13 @@ public class GenericRJ_Parameters {
 	
 	/**
 	 * This class is a container for the Generic Reasenberg-Jones parameters defined by 
-	 * Page et al. (2016, FILL IN REF AFTER PUBLICATION).  The distribution of a-values is assumed
+	 * Page et al. (2016, BSSA).  The distribution of a-values is assumed
 	 * to be Gaussian, with a mean of aValue_mean and a standard deviation of aValue_sigma.  
 	 * A magnitude-dependent sigma is an option, and can be computed as:
 	 * 
-	 * 		sigma(M) = (sigma0^2 + sigma1^2/10^M)^0.5 if M≥6
+	 * 		sigma(M) = (sigma0^2 + sigma1^2/10^M)^0.5 if M >= 6
 	 * or
-	 * 		sigma(M) = (sigma0^2 + sigma1^2/10^6)^0.5 if M<6
+	 * 		sigma(M) = (sigma0^2 + sigma1^2/10^6)^0.5 if M < 6
 	 * 
 	 * @param aValue_mean
 	 * @param aValue_sigma

--- a/src/scratch/aftershockStatistics/RJ_AftershockModel.java
+++ b/src/scratch/aftershockStatistics/RJ_AftershockModel.java
@@ -1,6 +1,7 @@
 package scratch.aftershockStatistics;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 
 import org.apache.commons.math3.distribution.PoissonDistribution;
 import org.mongodb.morphia.annotations.Transient;
@@ -21,150 +22,705 @@ import org.opensha.sha.magdist.IncrementalMagFreqDist;
  * 
  * Subclasses should normalize Likelihood values so they sum to 1.0 over the range of parameter-values specified;
  * this can be accomplished using the convertArrayToLikelihood(double maxLogLikeVal) method.
- * 
  *
  * @author field
  *
+ * Modified by Michael Barall.
+ *
+ * WARNING: This object is stored in the OAF database. Once OAF becomes operational,
+ * the set of non-Transient fields can never be changed.
+ *
+ * This model includes both aleatory uncertainty (uncertainty due to randomness in nature)
+ * and epistemic uncertainty (uncertainty due to our lack of knowledge of the correct
+ * parameter values).
+ *
+ * The aleatory uncertainty is represented by a Reasenberg-Jones probability distribution.
+ * According to R&J, the rate of aftershocks of magnitude >= magMin is
+ *  lambda(t) = k * (t + c)^(-p)
+ * where
+ *  k = 10^(a + b*(magMain - magMin))
+ * Here time t is measured in days, and lambda(t) is events per day.  The parameters are:
+ *  a = Reasenberg-Jones productivity
+ *  b = Gutenberg-Richter exponent
+ *  c = Omori offset
+ *  p = Omori exponent
+ *
+ * In a time interval [tMin, tMax], the expected number of aftershocks is the integral
+ * of lambda(t) from tMin to tMax:
+ *  lambda(tMin, tMax) = INTEGRAL(lambda(t) * dt, tMin <= t <= tMax)
+ * The actual number of aftershocks in the time interval is assumed to be a Poisson random
+ * variable with expected value equal to lambda(tMin, tMax).  So the probability of there
+ * being n aftershocks in the time interval [tMin, tMax] is
+ *  PA(n) = exp(-lambda(tMin, tMax)) * (lambda(tMin, tMax))^n / n!
+ * The notation PA(n) indicates this is probability due to aleatory uncertainty.
+ *
+ * Epistemic uncertainty is introduced by treating the parameter triple (a,p,c) as a
+ * random variable, with probability density function rho(a,p,c).  The parameter b is
+ * considered to be known, and so there is no probability distribution associated with b.
+ * Then, the probability of there being n aftershocks in the time interval [tMin, tMax],
+ * taking into account both aleatory and epistemic uncertainty, is
+ *  PAE(n) = INTEGRAL(PA(n) * rho(a,p,c) * da * dp * dc)
+ * where the integration runs over all allowed values of a, p, and c.
+ * Notice that this is a non-Poissonian distribution.
+ *
+ * In this model, the probability density rho(a,p,c) is taken to be a discrete function,
+ * which is defined on a uniformly-spaced grid of points in (a,p,c) space.  Each of the
+ * three parameters a, p, and c is allowed to assume a set of evenly-spaced discrete values,
+ * ranging from min_a to max_a, min_p to max_p, and min_c to max_c respectively.  The
+ * probabilities are stored in a three-dimensional array, and the array elements are
+ * normalized so they sum to 1.  Then the integral is replaced with a sum:
+ *  PAE(n) = SUM(PA(n) * rho(a,p,c), min_a <= a <= max_a, min_p <= p <= max_p, min_c <= c <= max_c)
+ *
+ * This is an abstract class.  The main job of a subclass is to supply the probability
+ * distribution rho(a,p,c).
  */
 public abstract class RJ_AftershockModel {
 
-	@Transient
-	Boolean D=true;	// debug flag
-	
-	double b, magMain; 
-	double min_a, max_a, delta_a=0, min_p, max_p, delta_p=0, min_c, max_c, delta_c=0;
-	int num_a, num_p, num_c;
-	@Transient
-	double[][][]  array;
-	int max_a_index=-1;
-	int max_p_index=-1;
-	int max_c_index=-1;
-	@Transient
-	ArbDiscrEmpiricalDistFunc numMag5_DistributionFunc = null;
-	double tMinDaysCurrent=-1, tMaxDaysCurrent=-1;
+	//----- Fields that must be set by the subclass -----
 
-	
-	/**
-	 * This converts the array from log-likelihood to likelihood values, making sure NaNs do not occur 
-	 * due to high logLikelihoods, and re-normalizes the array so as values sum to 1.0.
-	 * @param maxLogLikeVal - the maximum values in the input array
-	 * @return
-	 */
-	protected double convertLogLikelihoodArrayToLikelihood(double maxLogLikeVal) {
-		double total=0;
-		double corr = 0;
-		if(maxLogLikeVal>100.0)	// values above ~700 cause NaNs from Math.exp(), so we subtract some number from all values to avoid such numerical problems
-			corr = maxLogLikeVal-100;
-		for(int aIndex=0;aIndex<num_a;aIndex++) {
-			for(int pIndex=0;pIndex<num_p;pIndex++) {
-				for(int cIndex=0;cIndex<num_c;cIndex++) {
-					double like = Math.exp(array[aIndex][pIndex][cIndex]-corr);
-					array[aIndex][pIndex][cIndex] = like;
-					total += array[aIndex][pIndex][cIndex];
-				}
-			}
-		}
+	// Debug flag.
+	// When set to true, some values are written to System.out, which are logged in the OAF server.
 
-		// now re-normalize all likelihood values so they sum to 1.0
-		double testTotal=0;
-		for(int aIndex=0;aIndex<num_a;aIndex++) {
-			for(int pIndex=0;pIndex<num_p;pIndex++) {
-				for(int cIndex=0;cIndex<num_c;cIndex++) {
-					array[aIndex][pIndex][cIndex] /= total;
-					testTotal += array[aIndex][pIndex][cIndex];
-				}
-			}
-		}
-		return testTotal;
-	}
+	@Transient
+	protected boolean D = true;	// debug flag
+
+	// The Gutenberg-Richter b-value
+	// This is set to a fixed value by the subclass.
 	
-	public double getMaxLikelihood_a() { return get_a(max_a_index);}
+	protected double b = 0.0; 
+
+	// The magnitude of the mainshock.
+	// This is set to a fixed value by the subclass.
 	
-	public double getMaxLikelihood_p() { return get_p(max_p_index);}
+	protected double magMain = 0.0; 
+
+	// The parameter space for the Reasenberg-Jones productivity parameter a and the Omori parameters p and c.
+	// This class considers a discrete set of a-values, ranging from min_a to max_a.
+	// There are num_a different values, evenly spaced with spacing delta_a, hence delta_a = (max_a - min_a)/(num_a - 1).
+	// (If num_a == 1 then max_a == min_a and delta_a == 0.)
+	// The p-values and c-values are discretized in the same way.
+
+	protected double min_a = 0.0;
+	protected double max_a = 0.0;
+	protected double delta_a = 0.0;
+	protected int num_a = 1;
+
+	protected double min_p = 0.0;
+	protected double max_p = 0.0;
+	protected double delta_p = 0.0;
+	protected int num_p = 1;
+
+	protected double min_c = 0.0;
+	protected double max_c = 0.0;
+	protected double delta_c = 0.0;
+	protected int num_c = 1;
+
+	// Likelihood values for each parameter triple (a, p, c).
+	// The dimensions are apc_likelihood[num_a][num_p][num_c].
+	// This array may contain either likelihood or log-likelihood depending on the context.
+	// Note: A subclass or user of this class must supply the likelihood values.
+	// They are not computed in this class.
+
+	@Transient
+	protected double[][][] apc_likelihood = null;
+
+	// The fraction of the (a,p,c) probability distribution that can be ignored as negligably small.
+
+	protected double apc_tail_fraction = 0.0001;
+
+	//----- Fields that are set and used by this class -----
+
+	// Index values for the maximum likelihood parameter triple (a, p, c).
+	// In other words, apc_likelihood[max_a_index][max_p_index][max_c_index] is the largest element in apc_likelihood.
+	// Note: This identifies the maximum likelihood values, considering the parameters to form a triple (a, p, c).
+	// It does NOT identify the maximum likelihood values of each parameter considered separately.
+
+	protected int max_a_index = -1;
+	protected int max_p_index = -1;
+	protected int max_c_index = -1;
+
+	// Total size of the apc_likelihood matrix.
+	// This is num_a * num_p * num_c.
+
+	protected int apc_total_size = -1;
+
+	// Total number of apc_likelihood elements in the support.
+	// The support consists of elements not in the tail, and so not negligable.
+
+	protected int apc_support_size = -1;
+
+	// Total of all the apc_likelihood elements in the support.
+	// This will be very close to 1.0.
+
+	protected double apc_support_total = 1.0;
+
+	// The maximum element in the tail of the apc_likelihood distribution.
+	// Elements are in the tail, and considered negligable, if <= apc_max_tail_element.
+
+	protected double apc_max_tail_element = 0.0;
+
+	// The range of index values that contain the support of the (a,p,c) probability distribution.
+	// (The support is the portion that is outside the tail, that is, non-negligable.)
+
+	protected int a_support_lo = -1;
+	protected int a_support_hi = -1;
+
+	protected int p_support_lo = -1;
+	protected int p_support_hi = -1;
+
+	protected int c_support_lo = -1;
+	protected int c_support_hi = -1;
+
+	// The calculated mean, standard deviation, and maximum likelihood value of each parameter.
+
+	protected double stat_a_mean = 0.0;
+	protected double stat_a_sdev = 0.0;
+	protected double stat_a_like = 0.0;
+
+	protected double stat_p_mean = 0.0;
+	protected double stat_p_sdev = 0.0;
+	protected double stat_p_like = 0.0;
+
+	protected double stat_c_mean = 0.0;
+	protected double stat_c_sdev = 0.0;
+	protected double stat_c_like = 0.0;
+
+	// This is a discrete function that represents likelihood as a function of the number of aftershocks
+	// of magnitude >= 5 during the time interval tMinDaysCurrent <= t <= tMaxDaysCurrent.
+	// Specifically, this function is a collection of points (x,y) where:
+	//  x = Expected number of aftershocks, as computed by the R&J formula.
+	//  y = Likelihood, obtained from apc_likelihood[aIndex][pIndex][cIndex].
+	// The set of points is obtained by iterating aIndex, pIndex, and cIndex over their ranges.
+	// If two points have exactly the same x-value, they are combined by adding their y-values.
+	// (The combination is done in class EmpiricalPoint2DToleranceSortedList.)
+	//
+	// The use of magnitude 5 is arbitrary.  According to the R&J formula, results for any other
+	// magnitude threshold M can by obtained by multiplying all x values by 10^(b*(5 - M)).
+	//
+	// Conceptually, this function captures the epistemic uncertainty associated with the
+	// uncertainty in the parameters (a,p,c).  The triple (a,p,c) is considered to be a random
+	// variable, whose probability density is given by apc_likelihood.  The R&J expected number
+	// of aftershocks is then a function of (a,p,c) and so has an induced probability
+	// distribution.  This function is the induced probability density.
+	//
+	// Note that the x-values of this function are themselves merely expected numbers of
+	// aftershocks.  Even if "correct" values of (a,p,c) were known, there would still be
+	// aleatory uncertainty due to randomness in nature, which causes the observed number
+	// of aftershocks to differ from the expected number.
+	//
+	// This function must be used with care, because the x-values are neither equally-spaced
+	// nor binned.  You can use numMag5_DistributionFunc.getMean(),
+	// numMag5_DistributionFunc.getStdDev(), and numMag5_DistributionFunc.getInterpolatedFractile(fractile)
+	// to get the mean, standard deviation, and fractile of the R&J expected number of
+	// aftershocks.  But, for example, a naive computation of the mode would be wrong.
+
+	@Transient
+	protected ArbDiscrEmpiricalDistFunc numMag5_DistributionFunc = null;
+
+	// The time interval used to calculate numMag5_DistributionFunc,
+	// measured in days after the mainshock.
+	// Note: The value of numMag5_DistributionFunc is cached so it need not be recomputed
+	// every time it is needed.  The values of tMinDaysCurrent and tMaxDaysCurrent are
+	// used to check whether recomputation is needed.
+
+	@Transient
+	protected double tMinDaysCurrent = -1.0;
+	@Transient
+	protected double tMaxDaysCurrent = -1.0;
+
+
+
+
+	// Return the maximum-likelihood value of a, p, or c.
+	// Note: These are the values of a, p, and c in the maximum-likelihood triple (a, p, c).
+	// They are NOT the maximum likelihood values of a, p, and c considered separately.
+	// Note: These are the a, p, and c values for the largest element in apc_likelihood.
 	
-	public double getMaxLikelihood_c() { return get_c(max_c_index);}
+	public double getMaxLikelihood_a() {return get_a(max_a_index);}
+	
+	public double getMaxLikelihood_p() {return get_p(max_p_index);}
+	
+	public double getMaxLikelihood_c() {return get_c(max_c_index);}
+
+	// Return the floating-point value of a, p, or c, given its index number.
 		
-	protected double get_a(int aIndex) { return min_a+aIndex*delta_a;}
+	protected double get_a(int aIndex) {return min_a+aIndex*delta_a;}
 	
-	protected double get_p(int pIndex) { return min_p+pIndex*delta_p;}
+	protected double get_p(int pIndex) {return min_p+pIndex*delta_p;}
 	
-	protected double get_c(int cIndex) { return min_c+cIndex*delta_c;}
+	protected double get_c(int cIndex) {return min_c+cIndex*delta_c;}
+
+	// Return the magnitude of the mainshock.
 	
+	public double getMainShockMag() {return magMain;}
+
+	// Return the Gutenberg-Richter b value.
 	
+	public double get_b() {return b;}
+
+	// Return the mean value of a, p, or c.
+
+	public double getMean_a() {return stat_a_mean;}
+	public double getMean_p() {return stat_p_mean;}
+	public double getMean_c() {return stat_c_mean;}
+
+	// Return the standard deviation of a, p, or c.
+
+	public double getStdDev_a() {return stat_a_sdev;}
+	public double getStdDev_p() {return stat_p_sdev;}
+	public double getStdDev_c() {return stat_c_sdev;}
+
+	// Return the maximum likelihood value of a, p, or c (alternate implementation).
+
+	public double getMaxLike_a() {return stat_a_like;}
+	public double getMaxLike_p() {return stat_p_like;}
+	public double getMaxLike_c() {return stat_c_like;}
+
+	// Return parameter space information.
+
+	public double getMin_a() {return min_a;}
+	public double getMin_p() {return min_p;}
+	public double getMin_c() {return min_c;}
+
+	public double getMax_a() {return max_a;}
+	public double getMax_p() {return max_p;}
+	public double getMax_c() {return max_c;}
+
+	public double getDelta_a() {return delta_a;}
+	public double getDelta_p() {return delta_p;}
+	public double getDelta_c() {return delta_c;}
+
+	public int getNum_a() {return num_a;}
+	public int getNum_p() {return num_p;}
+	public int getNum_c() {return num_c;}
+
+
+
+
+	/**
+	 * Turn verbose mode on or off.
+	 */
+	public void set_verbose(boolean f_verbose) {
+		D = f_verbose;
+		return;
+	}
+
+
+
+
+	/**
+	 * Set the tail fraction that is used for clipping the (a,p,c) probability distribution.
+	 * It could be set to zero (or a very small value) if the (a,p,c) distribution
+	 * has already been clipped external to this class.
+	 * For example, the default value of 0.0001 means to throw out the smallest elements
+	 * in apc_likelihood (after normalizing it) until their total reaches apc_tail_fraction.
+	 */
+	public void set_tail_fraction(double apc_tail_fraction) {
+		this.apc_tail_fraction = apc_tail_fraction;
+		return;
+	}
+
+
+
+
+	/**
+	 * Set a fixed value of parameter a.
+	 */
+	protected void set_fixed_a(double a) {
+		num_a = 1;
+		min_a = a;
+		max_a = a;
+		delta_a = 0.0;
+		return;
+	}
+
+
+
+
+	/**
+	 * Set a fixed value of parameter p.
+	 */
+	protected void set_fixed_p(double p) {
+		num_p = 1;
+		min_p = p;
+		max_p = p;
+		delta_p = 0.0;
+		return;
+	}
+
+
+
+
+	/**
+	 * Set a fixed value of parameter c.
+	 */
+	protected void set_fixed_c(double c) {
+		num_c = 1;
+		min_c = c;
+		max_c = c;
+		delta_c = 0.0;
+		return;
+	}
+
+
+
+
+	/**
+	 * Return the name of this model.
+	 */
+	public abstract String getModelName();
+
+	
+
+
+	/**
+	 * Finish setting up apc_likelihood, which contains the (a,p,c) probability distribution.
+	 * @param f_log = True if apc_likelihood contains log-likelihood, false if it contains likelihood.
+	 * @return
+	 * Convert log-likelihood to likelihood if necessary.
+	 * Identify the tail of the distribution.
+	 * Normalize the likelihood values so they sum to 1.0.
+	 */
+	protected void apcFinish(boolean f_log) {
+
+		// Error if matrix is so large it cannot be stored in a one-dimensional matrix.
+		// (Maybe should use a lower limit than Integer.MAX_VALUE)
+
+		if (((Integer.MAX_VALUE / num_a) / num_p) / num_c == 0) {
+			throw new RuntimeException("RJ_AftershockModel: Parameter likelihood matrix is too large");
+		}
+
+		// Invalidate the event count likelihood function
+
+		numMag5_DistributionFunc = null;
+		tMinDaysCurrent = -1.0;
+		tMaxDaysCurrent = -1.0;
+
+		// Find the biggest element in the matrix
+
+		double max_element = apc_likelihood[0][0][0];
+		max_a_index = 0;
+		max_p_index = 0;
+		max_c_index = 0;
+
+		for (int aIndex = 0; aIndex < num_a; aIndex++) {
+			for (int pIndex = 0; pIndex < num_p; pIndex++) {
+				for (int cIndex = 0; cIndex < num_c; cIndex++) {
+					if (apc_likelihood[aIndex][pIndex][cIndex] > max_element) {
+						max_element = apc_likelihood[aIndex][pIndex][cIndex];
+						max_a_index = aIndex;
+						max_p_index = pIndex;
+						max_c_index = cIndex;
+					}
+				}
+			}
+		}
+
+		// If matrix contains log likelihood, convert it to likelihood
+
+		if (f_log) {
+			for (int aIndex = 0; aIndex < num_a; aIndex++) {
+				for (int pIndex = 0; pIndex < num_p; pIndex++) {
+					for (int cIndex = 0; cIndex < num_c; cIndex++) {
+						apc_likelihood[aIndex][pIndex][cIndex] = Math.exp(apc_likelihood[aIndex][pIndex][cIndex] - max_element);
+									// subtract max_element to avoid overflows
+					}
+				}
+			}
+			max_element = 1.0;
+		}
+
+		// Check for nonzero probabilities
+
+		if (max_element < Double.MIN_NORMAL * 1.0e16) {
+			throw new RuntimeException("RJ_AftershockModel: Parameter likelihood matrix effective zero");
+		}
+
+		// Initialize for statistics computation
+
+		stat_a_mean = 0.0;
+		stat_a_sdev = 0.0;
+		stat_a_like = getMaxLikelihood_a();
+
+		stat_p_mean = 0.0;
+		stat_p_sdev = 0.0;
+		stat_p_like = getMaxLikelihood_p();
+
+		stat_c_mean = 0.0;
+		stat_c_sdev = 0.0;
+		stat_c_like = getMaxLikelihood_c();
+
+		// Calculate total weight of the matrix, and calculate the means
+
+		double total_weight = 0.0;
+		for (int aIndex = 0; aIndex < num_a; aIndex++) {
+			double a = get_a(aIndex);
+			for (int pIndex = 0; pIndex < num_p; pIndex++) {
+				double p = get_p(pIndex);
+				for (int cIndex = 0; cIndex < num_c; cIndex++) {
+					double c = get_c(cIndex);
+					double w = apc_likelihood[aIndex][pIndex][cIndex];
+					total_weight += w;
+					stat_a_mean += a * w;
+					stat_p_mean += p * w;
+					stat_c_mean += c * w;
+				}
+			}
+		}
+
+		stat_a_mean /= total_weight;
+		stat_p_mean /= total_weight;
+		stat_c_mean /= total_weight;
+
+		// Normalize the matrix so it sums to 1.0, and dump the normalized values to a one-dimensional array,
+		// and compute the standard deviations
+
+		apc_total_size = num_a * num_p * num_c;
+		double[] apc_sorted = new double[apc_total_size];
+		int sIndex = 0;
+
+		for (int aIndex = 0; aIndex < num_a; aIndex++) {
+			double a = get_a(aIndex);
+			for (int pIndex = 0; pIndex < num_p; pIndex++) {
+				double p = get_p(pIndex);
+				for (int cIndex = 0; cIndex < num_c; cIndex++) {
+					double c = get_c(cIndex);
+					double w = apc_likelihood[aIndex][pIndex][cIndex] / total_weight;
+					apc_likelihood[aIndex][pIndex][cIndex] = w;
+					apc_sorted[sIndex++] = w;
+					stat_a_sdev += (a - stat_a_mean) * (a - stat_a_mean) * w;
+					stat_p_sdev += (p - stat_p_mean) * (p - stat_p_mean) * w;
+					stat_c_sdev += (c - stat_c_mean) * (c - stat_c_mean) * w;
+				}
+			}
+		}
+
+		stat_a_sdev = Math.sqrt(stat_a_sdev);
+		stat_p_sdev = Math.sqrt(stat_p_sdev);
+		stat_c_sdev = Math.sqrt(stat_c_sdev);
+
+		if (num_a == 1) {
+			stat_a_mean = min_a;
+			stat_a_sdev = 0.0;
+		}
+
+		if (num_p == 1) {
+			stat_p_mean = min_p;
+			stat_p_sdev = 0.0;
+		}
+
+		if (num_c == 1) {
+			stat_c_mean = min_c;
+			stat_c_sdev = 0.0;
+		}
+
+		// Sort the array from low to high
+
+		Arrays.sort (apc_sorted, 0, apc_total_size);
+
+		// Scan the sorted array to find the largest tail element
+
+		apc_max_tail_element = 0.0;
+		double tail_weight = apc_sorted[0];		// sum of all elements prior to sIndex
+		for (sIndex = 1; sIndex < apc_total_size && tail_weight <= apc_tail_fraction; ++sIndex) {
+
+			// If greater than the prior element, then the prior element could be the last element of the tail
+			// (Don't let the tail end in the middle of a run of equal elements)
+
+			if (apc_sorted[sIndex] > apc_sorted[sIndex - 1]) {
+				apc_max_tail_element = apc_sorted[sIndex - 1];
+			}
+
+			// Add current element to tail weight
+
+			tail_weight += apc_sorted[sIndex];
+		}
+
+		// Get the support bounds and total
+
+		apc_support_size = 0;
+		apc_support_total = 0.0;
+
+		a_support_lo = num_a;
+		a_support_hi = 0;
+
+		p_support_lo = num_p;
+		p_support_hi = 0;
+
+		c_support_lo = num_c;
+		c_support_hi = 0;
+
+		for (int aIndex = 0; aIndex < num_a; aIndex++) {
+			for (int pIndex = 0; pIndex < num_p; pIndex++) {
+				for (int cIndex = 0; cIndex < num_c; cIndex++) {
+					if (apc_likelihood[aIndex][pIndex][cIndex] > apc_max_tail_element) {
+						++apc_support_size;
+						apc_support_total += apc_likelihood[aIndex][pIndex][cIndex];
+						a_support_lo = Math.min(a_support_lo, aIndex);
+						a_support_hi = Math.max(a_support_hi, aIndex + 1);
+						p_support_lo = Math.min(p_support_lo, pIndex);
+						p_support_hi = Math.max(p_support_hi, pIndex + 1);
+						c_support_lo = Math.min(c_support_lo, cIndex);
+						c_support_hi = Math.max(c_support_hi, cIndex + 1);
+					}
+				}
+			}
+		}
+
+		// Verbose output if desired
+		
+		if(D) {
+			System.out.println(String.format("b=%.4g  magMain=%.4g  apcTot=%d  apcSup=%d",
+				b, magMain, apc_total_size, apc_support_size));
+			System.out.println(String.format("a: like=%.4g  mean=%.4g  sdev=%.4g  min=%.4g  max=%.4g  delta=%.4g  num=%d  lo=%d  hi=%d",
+				stat_a_like, stat_a_mean, stat_a_sdev, min_a, max_a, delta_a, num_a, a_support_lo, a_support_hi));
+			System.out.println(String.format("p: like=%.4g  mean=%.4g  sdev=%.4g  min=%.4g  max=%.4g  delta=%.4g  num=%d  lo=%d  hi=%d",
+				stat_p_like, stat_p_mean, stat_p_sdev, min_p, max_p, delta_p, num_p, p_support_lo, p_support_hi));
+			System.out.println(String.format("c: like=%.4g  mean=%.4g  sdev=%.4g  min=%.4g  max=%.4g  delta=%.4g  num=%d  lo=%d  hi=%d",
+				stat_c_like, stat_c_mean, stat_c_sdev, min_c, max_c, delta_c, num_c, c_support_lo, c_support_hi));
+		}
+
+		return;
+	}
+
+	
+
 	
 	/**
-	 * This computes the distribution of the number of M≥5.0 events given all a, p, and c values, as well as the associated
+	 * This computes the distribution of the number of M >= 5.0 events given all a, p, and c values, as well as the associated
 	 * weight for each set of values.  This is used as a reference function that can be scaled to other magnitudes for greater
 	 * efficiency.
-	 * @param tMinDays
-	 * @param tMaxDays
+	 * @param tMinDays = Beginning of the time interval, in days since the mainshock.
+	 * @param tMaxDays = End of the time interval, in days since the mainshock.
+	 * @return
+	 * See comments for numMag5_DistributionFunc above.
+	 * This uses only the elements in the support of apc_likelihood.
 	 */
 	public ArbDiscrEmpiricalDistFunc computeNumMag5_DistributionFunc(double tMinDays, double tMaxDays) {
 		
-		if(tMinDaysCurrent == tMinDays && tMaxDaysCurrent == tMaxDays && numMag5_DistributionFunc != null) // already computed
+		// If we already have a function computed for this time interval, then just return it
+
+		if(tMinDaysCurrent == tMinDays && tMaxDaysCurrent == tMaxDays && numMag5_DistributionFunc != null) { // already computed
 			return numMag5_DistributionFunc;
+		}
+
+		// Allocate a new function for this time interval
 		
 		tMinDaysCurrent = tMinDays;
 		tMaxDaysCurrent = tMaxDays;
 		numMag5_DistributionFunc = new ArbDiscrEmpiricalDistFunc();
-		for(int aIndex=0;aIndex<num_a;aIndex++) {
-			for(int pIndex=0;pIndex<num_p;pIndex++) {
-				for(int cIndex=0;cIndex<num_c;cIndex++) {
-					double numM5 = AftershockStatsCalc.getExpectedNumEvents(get_a(aIndex), b, magMain, 5.0, get_p(pIndex), get_c(cIndex), tMinDays, tMaxDays);;
-					numMag5_DistributionFunc.set(numM5, array[aIndex][pIndex][cIndex]);
+
+		// Add points to the function, x = expected number of M5 aftershocks, y = probability of (a,p,c)
+
+		for (int aIndex = a_support_lo; aIndex < a_support_hi; aIndex++) {
+			for (int pIndex = p_support_lo; pIndex < p_support_hi; pIndex++) {
+				for (int cIndex = c_support_lo; cIndex < c_support_hi; cIndex++) {
+					if (apc_likelihood[aIndex][pIndex][cIndex] > apc_max_tail_element) {
+						double numM5 = AftershockStatsCalc.getExpectedNumEvents(get_a(aIndex), b, magMain, 5.0, get_p(pIndex), get_c(cIndex), tMinDays, tMaxDays);
+						numMag5_DistributionFunc.set(numM5, apc_likelihood[aIndex][pIndex][cIndex] / apc_support_total);
+					}
 				}
 			}
 		}
+
+		// Debug or verbose output
+
 		if(D) {
-			System.out.println("N≥5 mean = "+numMag5_DistributionFunc.getMean());
-			System.out.println("N≥5 mode = "+numMag5_DistributionFunc.getApparentMode());
-			System.out.println("N≥5 median = "+numMag5_DistributionFunc.getMedian());
-			System.out.println("N≥5 2.5 Percentile = "+numMag5_DistributionFunc.getInterpolatedFractile(0.025));
-			System.out.println("N≥5 97.5 Percentile = "+numMag5_DistributionFunc.getInterpolatedFractile(0.975));
+			System.out.println("M>=5 mean = "+numMag5_DistributionFunc.getMean());
+			System.out.println("M>=5 mode (caution) = "+numMag5_DistributionFunc.getApparentMode());
+			System.out.println("M>=5 median = "+numMag5_DistributionFunc.getMedian());
+			System.out.println("M>=5 2.5 Percentile = "+numMag5_DistributionFunc.getInterpolatedFractile(0.025));
+			System.out.println("M>=5 97.5 Percentile = "+numMag5_DistributionFunc.getInterpolatedFractile(0.975));
 		}
+
 		return numMag5_DistributionFunc;
 	}
 	
+
+
 	
 	/**
-	 * This gives the number of aftershocks associated with the maximum likelihood a/p/c parameters (which represents the mode
-	 * in the number of events space) above the given minimum magnitude and over the specified site span.  A GR distribution with
+	 * This gives the expected number of aftershocks associated with the maximum likelihood a/p/c parameters (which represents the mode
+	 * in the number of events space) above the given minimum magnitude and over the specified time span.  A GR distribution with
 	 * no upper bound is assumed.
-	 * @param magMin
-	 * @param tMinDays
-	 * @param tMaxDays
+	 * @param magMin = Minimum magnitude of aftershocks to consider.
+	 * @param tMinDays = Start of time range, in days after the mainshock.
+	 * @param tMaxDays = End of time range, in days after the mainshock.
 	 * @return
+	 * According to R&J, the rate of aftershocks of magnitude >= magMin is
+	 *  lambda(t) = k * (t + c)^(-p)
+	 * where
+	 *  k = 10^(a + b*(magMain - magMin))
+	 *  Parmeters a, p, and c are set to their maximum-likelihood values.
+	 *  Parameter b is set to the fixed value in this model.
+	 * The value returned by this function is the integral of lambda(t) from t=tMin to t=tMax.
+	 *
+	 * Note (MJB): References here and elsewhere to "the mode in the number of events space"
+	 * don't make sense to me.  There is a mapping from parameter triples (a,p,c) to expected
+	 * number of events, and so the probability density on parameter triples induces a
+	 * probability density on number of events.  But the mapping is non-linear and non-injective.
+	 * So, the mode of the former probability density does not necessarily map into the mode
+	 * of the latter probability density.  In other words: the most likely parameter triple
+	 * (a,p,c) does not necessarily yield the most likely expected number of events.  Functions
+	 * referring to "the mode in the number of events space" are actually computing values that
+	 * correspond to the maximum likelihood (a,p,c) triple.
 	 */
 	public double getModalNumEvents(double magMin, double tMinDays, double tMaxDays) {
 		return AftershockStatsCalc.getExpectedNumEvents(getMaxLikelihood_a(), b, magMain, magMin, getMaxLikelihood_p(), getMaxLikelihood_c(), tMinDays, tMaxDays);
 	}
 	
+
+
 	
 	/**
-	 * This gives the number of aftershocks as a function of time for the maximum likelihood a/p/c parameters 
+	 * This gives the expected cumulative number of aftershocks as a function of time for the maximum likelihood a/p/c parameters 
 	 * (which represents the mode in the number of events space) above the given minimum magnitude and over 
 	 * the specified time span.  A GR distribution with no upper bound is assumed.
-	 * @param magMin
-	 * @param tMinDays - left edge of first time intercal
-	 * @param tMaxDays - right edge of last time interval
-	 * @param tDelta
+	 * @param magMin = Minimum magnitude of aftershocks to consider.
+	 * @param tMinDays = Start of time range, in days after the mainshock.
+	 * @param tMaxDays = End of time range, in days after the mainshock.
+	 * @param tDelta = Spacing between time values in the returned function.
 	 * @return
+	 * Returns a discrete function with:
+	 *  x = time (in days after mainshock)
+	 *  y = cumulative expected number of aftershocks for the corresponding time interval.
+	 * The range [tMinDays, tMaxDays] is partitioned into equal-sized intervals, with the
+	 * width of each interval equal to approximately tDelta.  The interval width is
+	 * adjusted so that a whole number of intervals fit within the range [tMinDays, tMaxDays].
+	 * For each such interval, the x value is the midpoint of the interval (and so
+	 * the first and last x values are tMin+x_delta/2 and tMax-x_delta/2,
+	 * where x_delta is the adjusted interval width).  The y value is the expected
+	 * number of aftershocks within that interval plus all preceding intervals according
+	 * to the R&J formula.  In evaluating the R&J formula, parameters a, p, and c are set
+	 * to their maximum-likelihood values, and parameter b is the fixed value in this model.
 	 */
 	public EvenlyDiscretizedFunc getModalCumNumEventsWithTime(double magMin, double tMinDays, double tMaxDays, double tDelta) {
 		return AftershockStatsCalc.getExpectedCumulativeNumWithTimeFunc(getMaxLikelihood_a(), b, magMain, magMin, 
 				getMaxLikelihood_p(), getMaxLikelihood_c(), tMinDays, tMaxDays, tDelta);
 	}
 
+
+
 	
 	/**
 	 * This returns the cumulative MFD associated with the maximum likelihood a/p/c parameters (which represents the mode
-	 * in the number of events space) and over the specified site span.   A GR distribution with no upper bound is assumed.
+	 * in the number of events space) and over the specified time span.   A GR distribution with no upper bound is assumed.
 	 * @param minMag - the minimum magnitude considered
 	 * @param maxMag - the maximum magnitude considered
 	 * @param numMag - number of mags in the MFD
-	 * @param tMinDays
-	 * @param tMaxDays
+	 * @param tMinDays = Start of time range, in days after the mainshock.
+	 * @param tMaxDays = End of time range, in days after the mainshock.
 	 * @return
+	 * Returns a discrete function containing the cumulative magnitude-frequency distribution:
+	 *  x = Magnitude.
+	 *  y = Expected number of aftershocks with magnitude >= x, in the given time span.
+	 * The discrete function contains evenly-spaced x values, with the smallest x-value equal
+	 * to minMag and the largest x-value equal to maxMag.  The number of x-values is numMag.
+	 * If numMag==1 then minMag and maxMag must be exactly equal.
+	 * The expected number of aftershocks is computed using the R&J formula, with a, p, and c
+	 * set to their maximum-likelihood values, and b set to the fixed value in this model.
+	 *
+	 * Note: The result will be a Gutenberg-Richter distribution, with y proportional to 10^(-b*x).
 	 */
 	public EvenlyDiscretizedFunc getModalCumNumMFD(double minMag, double maxMag, int numMag, double tMinDays, double tMaxDays) {
 		EvenlyDiscretizedFunc mfd = new EvenlyDiscretizedFunc(minMag, maxMag, numMag);
@@ -179,51 +735,101 @@ public abstract class RJ_AftershockModel {
 //		mfd.setInfo("Total Expected Num = "+totExpNum);
 		return mfd;
 	}
+
 	
 	
 	
 	/**
 	 * This returns the mean cumulative MFD given each a/p/c parameter set, and the associated likelihood, 
-	 * for the specified site span.   A GR distribution with no upper bound is assumed.
+	 * for the specified time span.   A GR distribution with no upper bound is assumed.
 	 * @param minMag - the minimum magnitude considered
 	 * @param maxMag - the maximum magnitude considered
 	 * @param numMag - number of mags in the MFD
-	 * @param tMinDays
-	 * @param tMaxDays
+	 * @param tMinDays = Start of time range, in days after the mainshock.
+	 * @param tMaxDays = End of time range, in days after the mainshock.
 	 * @return
+	 * Returns a discrete function containing the cumulative magnitude-frequency distribution:
+	 *  x = Magnitude.
+	 *  y = Scaled expected number of aftershocks with magnitude >= x, in the given time span.
+	 * The discrete function contains evenly-spaced x values, with the smallest x-value equal
+	 * to minMag and the largest x-value equal to maxMag.  The number of x-values is numMag.
+	 * If numMag==1 then minMag and maxMag must be exactly equal.
+	 * The expected number of aftershocks is computed using the R&J formula, with a, p, and c
+	 * set to their maximum-likelihood values, and b set to the fixed value in this model.
+	 * Then, all the numbers of aftershocks are scaled, with a scale factor chosen so that the
+	 * expected number of magnitude >= 5 aftershocks equals the mean of numMag5_DistributionFunc
+	 * (which is the mean expected number of magnitude >= 5 aftershocks implied by the probability
+	 * distribution of the parameters (a,p,c)).
+	 * The choice of magnitude 5 is arbitrary; any other choice of magnitude would yield the
+	 * same result; which implies that every value in this MFD equals the mean expected number
+	 * of aftershocks implied by the probability distribution of (a,p,c).
+	 *
+	 * Note: The result will be a Gutenberg-Richter distribution, with y proportional to 10^(-b*x).
+	 * The constant of proportionality is chosen so that each y is the mean expected number of
+	 * aftershocks with magnitude >= x, according to the probability distribution on (a,p,c).
 	 */
 	public EvenlyDiscretizedFunc getMeanCumNumMFD(double minMag, double maxMag, int numMag, double tMinDays, double tMaxDays) {
 		// get the reference MFD, which we will scale to the mean
 		EvenlyDiscretizedFunc mfd = getModalCumNumMFD(minMag, maxMag, numMag, tMinDays, tMaxDays);
-		double m5val = mfd.getInterpolatedY(5.0);
+
+//		double m5val = mfd.getInterpolatedY(5.0);	// fails if minMag > 5 || maxMag < 5
+		double m5val = getModalNumEvents(5.0, tMinDays, tMaxDays);
+
 		computeNumMag5_DistributionFunc(tMinDays, tMaxDays);
 		mfd.scale(numMag5_DistributionFunc.getMean()/m5val);	// scale MFD to the mean at M5
 		mfd.setName("Mean Num Events");
 		mfd.setInfo("Cumulative distribution (greater than or equal to each magnitude)");
 		return mfd;
 	}
+
+
+
 	
 	/**
 	 * This returns the fractile MFD implied by each a/p/c parameter set and their associated likelihoods, 
-	 * for the specified site span.   A GR distribution with no upper bound is assumed.  Only epistemic uncertainty
+	 * for the specified time span.   A GR distribution with no upper bound is assumed.  Only epistemic uncertainty
 	 * is considered (no aleatory variability).
 	 * @param fractile - the fractile (percentile/100) for the distribution
 	 * @param minMag - the minimum magnitude considered
 	 * @param maxMag - the maximum magnitude considered
 	 * @param numMag - number of mags in the MFD
-	 * @param tMinDays
-	 * @param tMaxDays
+	 * @param tMinDays = Start of time range, in days after the mainshock.
+	 * @param tMaxDays = End of time range, in days after the mainshock.
 	 * @return
+	 * Returns a discrete function containing the fractile magnitude-frequency distribution:
+	 *  x = Magnitude.
+	 *  y = Scaled expected number of aftershocks with magnitude >= x, in the given time span.
+	 * The discrete function contains evenly-spaced x values, with the smallest x-value equal
+	 * to minMag and the largest x-value equal to maxMag.  The number of x-values is numMag.
+	 * If numMag==1 then minMag and maxMag must be exactly equal.
+	 * The expected number of aftershocks is computed using the R&J formula, with a, p, and c
+	 * set to their maximum-likelihood values, and b set to the fixed value in this model.
+	 * Then, all the numbers of aftershocks are scaled, with a scale factor chosen so that the
+	 * expected number of magnitude >= 5 aftershocks equals the fractile of numMag5_DistributionFunc
+	 * (which is the fractile expected number of magnitude >= 5 aftershocks implied by the probability
+	 * distribution of the parameters (a,p,c)).
+	 * In other words:  Given the probability distribution on (a,p,c), the parameter "fractile"
+	 * is the probability that the expected number of aftershocks of magnitude >= x is <= y.
+	 * The choice of magnitude 5 is arbitrary; any other choice of magnitude would yield the
+	 * same result; which implies that every value in this MFD equals the fractile expected
+	 * number of aftershocks implied by the probability distribution of (a,p,c).
+	 *
+	 * Note: The result will be a Gutenberg-Richter distribution, with y proportional to 10^(-b*x).
+	 * The constant of proportionality is chosen so that each y is the fractile expected number of
+	 * aftershocks with magnitude >= x, according to the probability distribution on (a,p,c).
 	 */
 	public EvenlyDiscretizedFunc getCumNumMFD_Fractile(double fractile, double minMag, double maxMag, int numMag, double tMinDays, double tMaxDays) {
 		// get the reference MFD, which we will scale
 		EvenlyDiscretizedFunc mfd = getModalCumNumMFD(minMag, maxMag, numMag, tMinDays, tMaxDays);
+
 		// get the modal value at M5
-		double m5val;
-		if (minMag > 5 || maxMag < 5)	// in case requested range does not include M5
-			m5val = getModalCumNumMFD(5d, 5d, 1, tMinDays, tMaxDays).getY(0);
-		else
-			m5val = mfd.getInterpolatedY(5.0);
+//		double m5val;
+//		if (minMag > 5 || maxMag < 5)	// in case requested range does not include M5
+//			m5val = getModalCumNumMFD(5d, 5d, 1, tMinDays, tMaxDays).getY(0);
+//		else
+//			m5val = mfd.getInterpolatedY(5.0);
+		double m5val = getModalNumEvents(5.0, tMinDays, tMaxDays);
+
 		computeNumMag5_DistributionFunc(tMinDays, tMaxDays);
 		mfd.scale(numMag5_DistributionFunc.getInterpolatedFractile(fractile)/m5val);
 		mfd.setName(fractile+" Fractile for Num Events");
@@ -231,18 +837,34 @@ public abstract class RJ_AftershockModel {
 		return mfd;
 	}
 
+
+
 	
 	/**
 	 * This returns the fractile MFDs implied by each a/p/c parameter set and their associated likelihoods, 
-	 * for the specified site span.   A GR distribution with no upper bound is assumed.  Both epistemic uncertainty
+	 * for the specified time span.   A GR distribution with no upper bound is assumed.  Both epistemic uncertainty
 	 * and aleatory variability are considered.
-	 * @param fractileArray - the fractile (percentile/100) for the distribution
+	 * @param fractileArray - Desired fractiles (percentile/100) of the probability distribution.
 	 * @param minMag - the minimum magnitude considered
 	 * @param maxMag - the maximum magnitude considered
 	 * @param numMag - number of mags in the MFD
-	 * @param tMinDays
-	 * @param tMaxDays
+	 * @param tMinDays = Start of time range, in days after the mainshock.
+	 * @param tMaxDays = End of time range, in days after the mainshock.
 	 * @return EvenlyDiscretizedFunc[]
+	 * The return value is an array whose length equals fractileArray.length.
+	 * Each element is a discrete function containing the fractile magnitude-frequency distribution:
+	 *  x = Magnitude.
+	 *  y = Fractile expected number of aftershocks with magnitude >= x, in the given time span.
+	 * Specifically: y is an integer value, which is the smallest number such that the probability
+	 * of there being y or fewer aftershocks of magnitude >= x is >= fractileArray[i].
+	 * More succinctly: y is the fractileArray[i] fractile of the number of aftershocks of magnitude >= x.
+	 * This computation takes into account both epistemic uncertainty (represented by the probability
+	 * distribution on the parameter triple (a,p,c)) and aleatory uncertainty (represented by a
+	 * Poisson distribution whose expected value equals the R&J expected number of aftershocks).
+	 * See getCumNumFractileWithAleatory for further info on the probability distribution.
+	 * Each discrete function contains evenly-spaced x values, with the smallest x-value equal
+	 * to minMag and the largest x-value equal to maxMag.  The number of x-values is numMag.
+	 * If numMag==1 then minMag and maxMag must be exactly equal.
 	 */
 	public EvenlyDiscretizedFunc[] getCumNumMFD_FractileWithAleatoryVariability(double[] fractileArray, double minMag, double maxMag, int numMag, double tMinDays, double tMaxDays) {
 		EvenlyDiscretizedFunc[] mfdArray = new EvenlyDiscretizedFunc[fractileArray.length];
@@ -263,23 +885,54 @@ public abstract class RJ_AftershockModel {
 		return mfdArray;
 	}
 
+
+
 	
 	/**
 	 * This provides the cumulative number for the given fractiles, where aleatory variability
 	 * is included in the result based on a Poisson distribution.
-	 * @param fractileArray
-	 * @param mag
-	 * @param tMinDays
-	 * @param tMaxDays
+	 * @param fractileArray = Desired fractiles (percentile/100) of the probability distribution.
+	 * @param mag = Minimum magnitude of aftershocks considered.
+	 * @param tMinDays = Start of time range, in days after the mainshock.
+	 * @param tMaxDays = End of time range, in days after the mainshock.
 	 * @return
+	 * This function constructs a probability distribution for number of aftershocks
+	 * of magnitude mag or greater, in the time interval from tMinDays to tMagDays,
+	 * which combines epistemic and aleatory uncertainty.
+	 * Epistemic uncertainty is represented by numMag5_DistributionFunc, which is the
+	 * probability distribution of the R&J expected number of aftershocks induced by the
+	 * probability distribution of the parameter triple (a,p,c).
+	 * Aleatory uncertainty is represented by a Poisson distribution whose expected value
+	 * equals the R&J expected number of aftershocks.
+	 * This function constructs a Poisson distribution for each set of parameter values (a,p,c),
+	 * and then sums all the Poisson distributions with weight equal to the probability
+	 * (i.e., likelihood) of the correponding (a,p,c) triple.
+	 * The return value is an array whose length equals fractileArray.length.
+	 * The i-th element of the return value is the fractileArray[i] fractile of the
+	 * probability distribution, which is defined to be the minimum number n of aftershocks
+	 * such that the probability of n or fewer aftershocks is >= fractileArray[i].
+	 * Note that, although the return type is double[], the return values are integers.
+	 *
+	 * Implementation notes:
+	 * Documentation for PoissonDistribution is here:
+	 * http://commons.apache.org/proper/commons-math/javadocs/api-3.6/org/apache/commons/math3/distribution/PoissonDistribution.html
+	 * Since we do not generate samples from PoissonDistribution, it is better to use the constructor:
+	 * PoissonDistribution(RandomGenerator rng, double p, double epsilon, int maxIterations)
+	 * Set rng = null so that it does not create a random number generator.
+	 * Set epsilon and maxIterations to their default values.
+	 * However, this constructor is apparently planned for removal from Apache Math 4.0,
+	 * so leave the original constructor commented-out in case it needs to be restored.
 	 */
 	public double[] getCumNumFractileWithAleatory(double[] fractileArray, double mag, double tMinDays, double tMaxDays) {
-		// compute the distribution for the expected num aftershocks with M≥5 (which we will scale to other magnitudes)
+		// compute the distribution for the expected num aftershocks with M >= 5 (which we will scale to other magnitudes)
 		computeNumMag5_DistributionFunc(tMinDays, tMaxDays);
+
 		// get the maximum expected num, which we will use to set the maximum num in the distribution function
 //System.out.print("\tworking on M "+mag+"\nunm="+numMag5_DistributionFunc.size()+"\n");
 		double maxExpNum = numMag5_DistributionFunc.getMaxX()*Math.pow(10d, b*(5-mag));
-		PoissonDistribution poissDist = new PoissonDistribution(maxExpNum);
+
+//		PoissonDistribution poissDist = new PoissonDistribution(maxExpNum);
+		PoissonDistribution poissDist = new PoissonDistribution(null, maxExpNum, PoissonDistribution.DEFAULT_EPSILON, PoissonDistribution.DEFAULT_MAX_ITERATIONS);
 		int maxAleatoryNum = poissDist.inverseCumulativeProbability(0.999);
 		
 		HistogramFunction cumDistFunc = new HistogramFunction(0d, (double)maxAleatoryNum,maxAleatoryNum+1);
@@ -290,13 +943,16 @@ public abstract class RJ_AftershockModel {
 //System.out.print(", "+i);
 			double expNum = numMag5_DistributionFunc.getX(i)*Math.pow(10d, b*(5-mag));
 			double wt = numMag5_DistributionFunc.getY(i);
-			poissDist = new PoissonDistribution(expNum);
+//			poissDist = new PoissonDistribution(expNum);
+			poissDist = new PoissonDistribution(null, expNum, PoissonDistribution.DEFAULT_EPSILON, PoissonDistribution.DEFAULT_MAX_ITERATIONS);
 			totWt+=wt;
 			
 			int minLoopVal = poissDist.inverseCumulativeProbability(0.0001);
 			int maxLoopVal = poissDist.inverseCumulativeProbability(0.9999);
 			if(maxLoopVal>cumDistFunc.size()-1)
 				maxLoopVal=cumDistFunc.size()-1;
+			if(minLoopVal < 0)
+				minLoopVal = 0;
 			for(int j=minLoopVal;j<=maxLoopVal;j++) {
 				distFunc[j] += poissDist.probability(j)*wt;
 			}
@@ -326,6 +982,7 @@ public abstract class RJ_AftershockModel {
 	}
 
 
+
 	
 	/**
 	 * This returns the PDF of a, which is a marginal distribution if either c or p 
@@ -342,7 +999,7 @@ public abstract class RJ_AftershockModel {
 			for(int aIndex=0;aIndex<num_a;aIndex++) {
 				for(int pIndex=0;pIndex<num_p;pIndex++) {
 					for(int cIndex=0;cIndex<num_c;cIndex++) {
-						hist.add(get_a(aIndex), array[aIndex][pIndex][cIndex]);
+						hist.add(get_a(aIndex), apc_likelihood[aIndex][pIndex][cIndex]);
 					}
 				}
 			}
@@ -350,14 +1007,17 @@ public abstract class RJ_AftershockModel {
 			if(num_p !=1 || num_c != 1)
 				name += " (marginal)";
 			hist.setName(name);
-			if(D) {
+//			if(D) {
 //				System.out.println("PDF of a-value:  "+hist);
-				System.out.println("PDF of a-value: totalTest = "+hist.calcSumOfY_Vals());
-			}
+//				System.out.println("PDF of a-value: totalTest = "+hist.calcSumOfY_Vals());
+//			}
 			hist.scale(1d/hist.getDelta());
 			return hist;
 		}
 	}
+
+
+
 	
 	/**
 	 * This returns the PDF of p, which is a marginal distribution if either a or c 
@@ -374,7 +1034,7 @@ public abstract class RJ_AftershockModel {
 			for(int aIndex=0;aIndex<num_a;aIndex++) {
 				for(int pIndex=0;pIndex<num_p;pIndex++) {
 					for(int cIndex=0;cIndex<num_c;cIndex++) {
-						hist.add(get_p(pIndex), array[aIndex][pIndex][cIndex]);
+						hist.add(get_p(pIndex), apc_likelihood[aIndex][pIndex][cIndex]);
 					}
 				}
 			}
@@ -382,13 +1042,16 @@ public abstract class RJ_AftershockModel {
 			if(num_a !=1 || num_c != 1)
 				name += " (marginal)";
 			hist.setName(name);
-			if(D) {
-				System.out.println("PDF of p-value: totalTest = "+hist.calcSumOfY_Vals());
-			}
+//			if(D) {
+//				System.out.println("PDF of p-value: totalTest = "+hist.calcSumOfY_Vals());
+//			}
 			hist.scale(1d/hist.getDelta());
 			return hist;
 		}
 	}
+
+
+
 	
 	/**
 	 * This returns the PDF of c, which is a marginal distribution if either a or p 
@@ -405,7 +1068,7 @@ public abstract class RJ_AftershockModel {
 			for(int aIndex=0;aIndex<num_a;aIndex++) {
 				for(int pIndex=0;pIndex<num_p;pIndex++) {
 					for(int cIndex=0;cIndex<num_c;cIndex++) {
-						hist.add(get_c(cIndex), array[aIndex][pIndex][cIndex]);
+						hist.add(get_c(cIndex), apc_likelihood[aIndex][pIndex][cIndex]);
 					}
 				}
 			}
@@ -413,13 +1076,15 @@ public abstract class RJ_AftershockModel {
 			if(num_a !=1 || num_p != 1)
 				name += " (marginal)";
 			hist.setName(name);
-			if(D) {
-				System.out.println("PDF of c-value: totalTest = "+hist.calcSumOfY_Vals());
-			}
+//			if(D) {
+//				System.out.println("PDF of c-value: totalTest = "+hist.calcSumOfY_Vals());
+//			}
 			hist.scale(1d/hist.getDelta());
 			return hist;
 		}
 	}
+
+
 
 	
 	/**
@@ -438,22 +1103,23 @@ public abstract class RJ_AftershockModel {
 				for(int pIndex=0;pIndex<num_p;pIndex++) {
 					for(int cIndex=0;cIndex<num_c;cIndex++) {
 						double prevVal = hist2D.get(aIndex,pIndex);
-						hist2D.set(aIndex,pIndex, prevVal+array[aIndex][pIndex][cIndex]);
+						hist2D.set(aIndex,pIndex, prevVal+apc_likelihood[aIndex][pIndex][cIndex]);
 					}
 				}
 			}
 //			String name = "2D PDF of a vs p";
 //			if(num_c != 1)
 //				name += " (marginal)";
-			if(D) {
-				System.out.println("2D PDF of a vs p: totalTest = "+hist2D.getSumZ());
-			}
+//			if(D) {
+//				System.out.println("2D PDF of a vs p: totalTest = "+hist2D.getSumZ());
+//			}
 			hist2D.scale(1d/(hist2D.getGridSpacingX()*hist2D.getGridSpacingY()));
 			return hist2D;
 		}
 	}
 
 	
+
 	
 	/**
 	 * This returns a 2D PDF for a and c, which is a marginal distribution if p 
@@ -471,20 +1137,23 @@ public abstract class RJ_AftershockModel {
 				for(int pIndex=0;pIndex<num_p;pIndex++) {
 					for(int cIndex=0;cIndex<num_c;cIndex++) {
 						double prevVal = hist2D.get(aIndex,cIndex);
-						hist2D.set(aIndex,cIndex, prevVal+array[aIndex][pIndex][cIndex]);
+						hist2D.set(aIndex,cIndex, prevVal+apc_likelihood[aIndex][pIndex][cIndex]);
 					}
 				}
 			}
 //			String name = "2D PDF of a vs c";
 //			if(num_p != 1)
 //				name += " (marginal)";
-			if(D) {
-				System.out.println("2D PDF of a vs c: totalTest = "+hist2D.getSumZ());
-			}
+//			if(D) {
+//				System.out.println("2D PDF of a vs c: totalTest = "+hist2D.getSumZ());
+//			}
 			hist2D.scale(1d/(hist2D.getGridSpacingX()*hist2D.getGridSpacingY()));
 			return hist2D;
 		}
 	}
+
+
+
 
 	/**
 	 * This returns a 2D PDF for c and p, which is a marginal distribution if a 
@@ -502,97 +1171,66 @@ public abstract class RJ_AftershockModel {
 				for(int pIndex=0;pIndex<num_p;pIndex++) {
 					for(int cIndex=0;cIndex<num_c;cIndex++) {
 						double prevVal = hist2D.get(cIndex,pIndex);
-						hist2D.set(cIndex,pIndex, prevVal+array[aIndex][pIndex][cIndex]);
+						hist2D.set(cIndex,pIndex, prevVal+apc_likelihood[aIndex][pIndex][cIndex]);
 					}
 				}
 			}
 //			String name = "2D PDF of c vs p";
 //			if(num_a != 1)
 //				name += " (marginal)";
-			if(D) {
-				System.out.println("2D PDF of c vs p: totalTest = "+hist2D.getSumZ());
-			}
+//			if(D) {
+//				System.out.println("2D PDF of c vs p: totalTest = "+hist2D.getSumZ());
+//			}
 			hist2D.scale(1d/(hist2D.getGridSpacingX()*hist2D.getGridSpacingY()));
 			return hist2D;
 		}
 	}
+
+
+
 	
 	/**
-	 * This sets the array and maximum likelihood values from the a-values in the given discretized function,
-	 *  and holding the other parameters fixed at the values given.  The array is normalized so values sum
+	 * This sets the apc_likelihood and maximum likelihood values from the a-values in the given discretized function,
+	 *  and holding the other parameters fixed at the values given.  The apc_likelihood is normalized so values sum
 	 *  to 1.0.
-	 * @param aValueFunc
-	 * @param b
-	 * @param p
-	 * @param c
+	 * @param aValueFunc = Function giving likelihood of Reasenberg-Jones productivity parameter a at equally-spaced values.
+	 * @param p = Omori p-parameter (exponent).
+	 * @param c = Omori c-parameter (time offset), in days.
+	 * Note: The caller must set up this.b and this.magMain.
+	 * This function sets up all the fields related to a, p, and c, including apc_likelihood.
+	 * The likelihood values in aValueFunc need not be normalized.
+	 * The values of p and c are considered to be known.
 	 */
-	protected void setArrayAndMaxLikelyValuesFrom_aValueFunc(EvenlyDiscretizedFunc aValueFunc, double b, double p, double c) {
-		this.delta_a = aValueFunc.getDelta();
-		this.min_a = aValueFunc.getMinX();
-		this.max_a = aValueFunc.getMaxX();
-		this.num_a = aValueFunc.size();
+	protected void setArrayAndMaxLikelyValuesFrom_aValueFunc(EvenlyDiscretizedFunc aValueFunc, double p, double c) {
+		
+		delta_a = aValueFunc.getDelta();
+		min_a = aValueFunc.getMinX();
+		max_a = aValueFunc.getMaxX();
+		num_a = aValueFunc.size();
 
-		this.num_p=1;
-		this.min_p=p;
-		this.max_p=p;
-		this.max_p_index=0;		
+		set_fixed_p(p);
+		set_fixed_c(c);
 		
-		this.num_c=1;
-		this.min_c=c;
-		this.max_c=c;
-		this.max_c_index=0;
-		
-		array = new double[num_a][num_p][num_c];
-		double maxWt= Double.NEGATIVE_INFINITY;
-		double totWt=0;
-		for(int aIndex=0;aIndex<num_a;aIndex++) {
+		apc_likelihood = new double[num_a][num_p][num_c];
+		for (int aIndex = 0; aIndex < num_a; aIndex++) {
 			double wt = aValueFunc.getY(aIndex);
-			array[aIndex][0][0] = wt;
-			totWt+=wt;
-			if(wt>maxWt) {
-				max_a_index=aIndex;
-				maxWt=wt;
-			}
-		}
-		// now normalize so that it sums to 1.0
-		double totTest=0;
-		for(int aIndex=0;aIndex<num_a;aIndex++) {
-			array[aIndex][0][0] /= totWt;
-			totTest += array[aIndex][0][0];
+			apc_likelihood[aIndex][0][0] = wt;
 		}
 
-		if(D) {
-			System.out.println("a-values range:\t"+min_a+"\t"+max_a+"\t"+num_a+"\t"+delta_a);
-			System.out.println("totTest="+(float)totTest);
-			System.out.println("getMaxLikelihood_a()="+getMaxLikelihood_a());
-			System.out.println("getMaxLikelihood_p()="+getMaxLikelihood_p());
-			System.out.println("getMaxLikelihood_c()="+getMaxLikelihood_c());
-		}
+		// Complete the likelihood setup
+
+		apcFinish (false);
 		
+		return;
 	}
-	
-	public double getMainShockMag() {return magMain;}
-	
-	public double get_b() {return b;}
 
 
-	// getters/setters commented out until needed:
-//	public double getMin_a() { return min_a;}
-//	public double getMin_p() { return min_p;}
-//	public double getMin_c() { return min_c;}
-//	public double getMax_a() { return max_a;}
-//	public double getMax_p() { return max_p;}
-//	public double getMax_c() { return max_c;}
-//	public double getDelta_a() { return delta_a;}
-//	public double getDelta_p() { return delta_p;}
-//	public double getDelta_c() { return delta_c;}
-//	public int getNum_a() { return num_a;}
-//	public int getNum_p() { return num_p;}
-//	public int getNum_c() { return num_c;}
+
 
 	public static void main(String[] args) {
 		// TODO Auto-generated method stub
 
+		return;
 	}
 
 }

--- a/src/scratch/aftershockStatistics/RJ_AftershockModel_Bayesian.java
+++ b/src/scratch/aftershockStatistics/RJ_AftershockModel_Bayesian.java
@@ -4,12 +4,6 @@ import java.awt.Color;
 import java.io.IOException;
 import java.util.ArrayList;
 
-import org.apache.commons.math3.analysis.UnivariateFunction;
-import org.apache.commons.math3.analysis.integration.IterativeLegendreGaussIntegrator;
-import org.apache.commons.math3.analysis.integration.LegendreGaussIntegrator;
-import org.apache.commons.math3.analysis.integration.RombergIntegrator;
-import org.apache.commons.math3.analysis.integration.SimpsonIntegrator;
-import org.apache.commons.math3.analysis.integration.TrapezoidIntegrator;
 import org.jfree.data.Range;
 import org.mongodb.morphia.annotations.Transient;
 import org.opensha.commons.data.function.EvenlyDiscretizedFunc;
@@ -34,10 +28,14 @@ import com.google.common.base.Preconditions;
  * This represents a Reasenberg-Jones (1989, 1994) aftershock model where the a-value distribution is the Bayesian
  * combination of two given models, and where b, p, and c are held fixed (and they must be the same in each model).
  * 
- * a-value discretization is the smallest between the two given models, and the a-value range if union of the two.
+ * a-value discretization is the smallest between the two given models, and the a-value range is the intersection of the two.
  * 
- * Note also that the Gaussian distribution is renormalized so that values sum to 1.0 over the final range of
+ * Note also that the probability distribution is renormalized so that values sum to 1.0 over the final range of
  * a-values represented.
+ *
+ * The probability density function of a in the Bayesian model, P(a), is proportional to:
+ *  P(a) = P1(a)*P2(a)
+ * where P1(a) and P2(a) are the probability density functions of a in the two models.
  * 
  * TODO:
  * 
@@ -45,107 +43,218 @@ import com.google.common.base.Preconditions;
  *
  * @author field
  *
+ * Modified by Michael Barall.
+ *
+ * WARNING: This object is stored in the OAF database. Once OAF becomes operational,
+ * the set of non-Transient fields can never be changed.
+ *
  */
 public class RJ_AftershockModel_Bayesian extends RJ_AftershockModel {
 
-	@Transient
-	Boolean D=true;	// debug flag
+//	@Transient
+//	protected boolean D=true;	// debug flag (inherited)
 
-    public RJ_AftershockModel_Bayesian() {
 
+
+
+	/**
+	 * Return the name of this model.
+	 */
+	@Override
+	public String getModelName() {
+		return "Reasenberg-Jones (1989, 1994) aftershock model (Bayesian Combination)";
+	}
+
+
+
+
+	/**
+	 * Return true if x1 and x2 are approximately equal (to 7 digits).
+	 */
+    public static boolean areParamsEquivalent(double x1, double x2) {
+		if (Math.abs(x1 - x2) <= 1.0e-7 * Math.max(Math.abs(x1), Math.abs(x2)) + Double.MIN_NORMAL) {
+			return true;
+		}
+		return false;
     }
 
+
+
+
     /**
-	 * Check similarity of both models, currently to floating point precision
+	 * Check similarity of both models, return true if the parameters are equivalent
 	 * 
-	 * @param model1
-	 * @param model2
+	 * @param model1 = First model to check.
+	 * @param model2 = Second model to check.
 	 * @return
+	 * Returns true if the models are similar, so that the Bayesian combination can be formed.
 	 */
 	public static boolean areModelsEquivalent(RJ_AftershockModel model1, RJ_AftershockModel model2) {
-		if ((float)model1.getMainShockMag() != (float)model2.getMainShockMag())
+		if (!( areParamsEquivalent (model1.getMainShockMag(), model2.getMainShockMag())
+			&& areParamsEquivalent (model1.get_b(), model2.get_b())
+			&& areParamsEquivalent (model1.getMaxLikelihood_p(), model2.getMaxLikelihood_p())
+			&& areParamsEquivalent (model1.getMaxLikelihood_c(), model2.getMaxLikelihood_c()) )) {
 			return false;
-		if ((float)model1.get_b() != (float)model2.get_b())
+		}
+		if (!( Math.max(model1.min_a, model2.min_a) < Math.min(model1.max_a, model2.max_a)
+			&& model1.num_a > 1 && model2.num_a > 1 )) {
 			return false;
-		if ((float)model1.getMaxLikelihood_p() != (float)model2.getMaxLikelihood_p())
-			return false;
-		if ((float)model1.getMaxLikelihood_c() != (float)model2.getMaxLikelihood_c())
-			return false;
+		}
 		return true;
 	}
+
+
+
 	
 	/**
 	 * This instantiates a Bayesian combination of the two given RJ models
-	 * @param model1
-	 * @param model2
+	 * @param model1 = First model to combine.
+	 * @param model2 = Second model to combine.
 	 */
 	public RJ_AftershockModel_Bayesian(RJ_AftershockModel model1, RJ_AftershockModel model2) {
-		
-		this.magMain = model1.getMainShockMag();
-		this.b = model1.get_b();
-		double p = model1.getMaxLikelihood_p();
-		double c = model1.getMaxLikelihood_c();
-		
-		// check similarity of these with the second model
+		setup_model(model1, model2);
+	}
+
+
+
+
+	/**
+	 * This default constructor creates an empty model.
+	 * This is intended for use in database retrieval.
+	 */
+    public RJ_AftershockModel_Bayesian() {
+		// When retrieving from database, remain quiet by default
+		D = false;
+    }
+
+
+
+
+	/**
+	 * Set up the model.
+	 * @param model1 = First model to combine.
+	 * @param model2 = Second model to combine.
+	 */
+    public void setup_model(RJ_AftershockModel model1, RJ_AftershockModel model2) {
+
+		// check similarity of the two models
 		Preconditions.checkArgument(areModelsEquivalent(model1, model2),
 				"Models are not equivalent so Bayesian combination impossible."
 						+"\n\tMain shock mags: %s, %s"
 						+"\n\tb-values: %s, %s"
 						+"\n\tp-values: %s, %s"
-						+"\n\tc-values: %s, %s",
-						model1.getMainShockMag(), model2.getMainShockMag(), model1.get_b(), model2.get_b(),
+						+"\n\tc-values: %s, %s"
+						+"\n\tmin a-values: %s, %s"
+						+"\n\tmax a-values: %s, %s"
+						+"\n\tnum a-values: %s, %s",
+						model1.getMainShockMag(), model2.getMainShockMag(),
+						model1.get_b(), model2.get_b(),
 						model1.getMaxLikelihood_p(), model2.getMaxLikelihood_p(),
-						model1.getMaxLikelihood_c(), model2.getMaxLikelihood_c());
+						model1.getMaxLikelihood_c(), model2.getMaxLikelihood_c(),
+						model1.min_a, model2.min_a,
+						model1.max_a, model2.max_a,
+						model1.num_a, model2.num_a);
 		
-		this.min_p=p;
-		this.max_p=p;
-		this.num_p=1;
-		this.min_c=c;
-		this.max_c=c;
-		this.num_c=1;
+		// Use averages here so that the construction is symmetric
+		this.magMain = 0.5*(model1.getMainShockMag() + model2.getMainShockMag());
+		this.b = 0.5*(model1.get_b() + model2.get_b());
+		double p = 0.5*(model1.getMaxLikelihood_p() + model2.getMaxLikelihood_p());
+		double c = 0.5*(model1.getMaxLikelihood_c() + model2.getMaxLikelihood_c());
+
+		set_fixed_p(p);
+		set_fixed_c(c);
 		
 		
 		HistogramFunction aValFunc1 =  model1.getPDF_a();
+		if (aValFunc1 == null) {
+			throw new RuntimeException("RJ_AftershockModel_Bayesian: aValFunc1 == null");
+		}
+
 		HistogramFunction aValFunc2 =  model2.getPDF_a();
+		if (aValFunc2 == null) {
+			throw new RuntimeException("RJ_AftershockModel_Bayesian: aValFunc2 == null");
+		}
+
 		this.min_a = Math.max(aValFunc1.getMinX(), aValFunc2.getMinX());
 		this.max_a = Math.min(aValFunc1.getMaxX(), aValFunc2.getMaxX());
+		if(min_a >= max_a) {
+			throw new RuntimeException("RJ_AftershockModel_Bayesian: aValueMin >= aValueMax");
+		}
+
 		double minDelta = Math.min(aValFunc1.getDelta(), aValFunc2.getDelta());
 		this.num_a = (int)Math.ceil((max_a-min_a)/minDelta) + 1;
-		EvenlyDiscretizedFunc aValueFuncBayes = new EvenlyDiscretizedFunc(min_a, max_a, num_a);
-		this.delta_a = aValueFuncBayes.getDelta();
-
-		if(min_a>max_a) {
-			throw new RuntimeException("Problem: aValueMin > aValueMax");
-		}
+		this.delta_a = (max_a - min_a)/((double)(num_a - 1));
 		
-		for(int i=0;i<aValueFuncBayes.size();i++) {
-			double a = aValueFuncBayes.getX(i);
+		apc_likelihood = new double[num_a][num_p][num_c];
+		for (int aIndex = 0; aIndex < num_a; aIndex++) {
+			double a = get_a(aIndex);
 			double wt = aValFunc1.getInterpolatedY(a)*aValFunc2.getInterpolatedY(a);
-			aValueFuncBayes.set(i,wt);
+			apc_likelihood[aIndex][0][0] = wt;
 		}
-		
-		setArrayAndMaxLikelyValuesFrom_aValueFunc(aValueFuncBayes, b, p, c);
-		
+
+		// Complete the likelihood setup
+
+		apcFinish (false);
+
+		return;
 	}
 	
 		
 
+
 	public static void main(String[] args) {
-		RJ_AftershockModel_Generic gen1 = new RJ_AftershockModel_Generic(7.0, -2, 0.3, -4.5, -0.5, 1.0, 1.12, 0.018);
-		RJ_AftershockModel_Generic gen2 = new RJ_AftershockModel_Generic(7.0, -3, 0.3, -4.5, -0.5, 1.0, 1.12, 0.018);
-		RJ_AftershockModel_Bayesian bayes = new RJ_AftershockModel_Bayesian(gen1,gen2);
+
+		// There needs to be at least one argument, which is the subcommand
+
+		if (args.length < 1) {
+			System.err.println ("RJ_AftershockModel_Bayesian : Missing subcommand");
+			return;
+		}
+
+
+		// Subcommand : Test #1
+		// Command format:
+		//  test1
+		// This is the pre-existing test for the class.
+
+		if (args[0].equalsIgnoreCase ("test1")) {
+
+			// No additional arguments
+
+			if (args.length != 1) {
+				System.err.println ("RJ_AftershockModel_Bayesian : Invalid 'test1' subcommand");
+				return;
+			}
+
+			// Run the test
 		
-		ArrayList<HistogramFunction> funcList = new ArrayList<HistogramFunction>();
-		funcList.add(gen1.getPDF_a());
-		funcList.add(gen2.getPDF_a());
-		funcList.add(bayes.getPDF_a());
-		ArrayList<PlotCurveCharacterstics> curveCharList = new ArrayList<PlotCurveCharacterstics>();
-		curveCharList.add(new PlotCurveCharacterstics(PlotLineType.SOLID, 2f, Color.BLACK));
-		curveCharList.add(new PlotCurveCharacterstics(PlotLineType.SOLID, 2f, Color.BLUE));
-		curveCharList.add(new PlotCurveCharacterstics(PlotLineType.SOLID, 2f, Color.RED));
-		GraphWindow numVsTimeGraph = new GraphWindow(funcList, "PDF"); 
-		numVsTimeGraph.setX_AxisLabel("a-value");
-		numVsTimeGraph.setY_AxisLabel("Density");
+			RJ_AftershockModel_Generic gen1 = new RJ_AftershockModel_Generic(7.0, -2, 0.3, -4.5, -0.5, 1.0, 1.12, 0.018);
+			RJ_AftershockModel_Generic gen2 = new RJ_AftershockModel_Generic(7.0, -3, 0.3, -4.5, -0.5, 1.0, 1.12, 0.018);
+			RJ_AftershockModel_Bayesian bayes = new RJ_AftershockModel_Bayesian(gen1,gen2);
+		
+			ArrayList<HistogramFunction> funcList = new ArrayList<HistogramFunction>();
+			funcList.add(gen1.getPDF_a());
+			funcList.add(gen2.getPDF_a());
+			funcList.add(bayes.getPDF_a());
+			ArrayList<PlotCurveCharacterstics> curveCharList = new ArrayList<PlotCurveCharacterstics>();
+			curveCharList.add(new PlotCurveCharacterstics(PlotLineType.SOLID, 2f, Color.BLACK));
+			curveCharList.add(new PlotCurveCharacterstics(PlotLineType.SOLID, 2f, Color.BLUE));
+			curveCharList.add(new PlotCurveCharacterstics(PlotLineType.SOLID, 2f, Color.RED));
+			GraphWindow numVsTimeGraph = new GraphWindow(funcList, "PDF"); 
+			numVsTimeGraph.setX_AxisLabel("a-value");
+			numVsTimeGraph.setY_AxisLabel("Density");
+
+			return;
+		}
+
+
+
+
+		// Unrecognized subcommand.
+
+		System.err.println ("RJ_AftershockModel_Bayesian : Unrecognized subcommand : " + args[0]);
+		return;
+
 	}
 
 }

--- a/src/scratch/aftershockStatistics/RJ_AftershockModel_Generic.java
+++ b/src/scratch/aftershockStatistics/RJ_AftershockModel_Generic.java
@@ -4,12 +4,6 @@ import java.awt.Color;
 import java.io.IOException;
 import java.util.ArrayList;
 
-import org.apache.commons.math3.analysis.UnivariateFunction;
-import org.apache.commons.math3.analysis.integration.IterativeLegendreGaussIntegrator;
-import org.apache.commons.math3.analysis.integration.LegendreGaussIntegrator;
-import org.apache.commons.math3.analysis.integration.RombergIntegrator;
-import org.apache.commons.math3.analysis.integration.SimpsonIntegrator;
-import org.apache.commons.math3.analysis.integration.TrapezoidIntegrator;
 import org.jfree.data.Range;
 import org.mongodb.morphia.annotations.Transient;
 import org.opensha.commons.data.function.ArbDiscrEmpiricalDistFunc;
@@ -47,12 +41,34 @@ import org.opensha.sha.magdist.GutenbergRichterMagFreqDist;
  *
  * @author field
  *
+ * Modified by Michael Barall.
+ *
+ * WARNING: This object is stored in the OAF database. Once OAF becomes operational,
+ * the set of non-Transient fields can never be changed.
+ *
  */
 public class RJ_AftershockModel_Generic extends RJ_AftershockModel {
 
-	@Transient
-	Boolean D=true;	// debug flag
-	double mean_a, sigma_a;
+//	@Transient
+//	protected boolean D=true;	// debug flag (inherited)
+
+	// Mean and standard deviation of the Gaussian distribution of a-values.
+
+	protected double mean_a = 0.0;
+	protected double sigma_a = 0.0;
+
+
+
+
+	/**
+	 * Return the name of this model.
+	 */
+	@Override
+	public String getModelName() {
+		return "Reasenberg-Jones (1989, 1994) aftershock model (Generic)";
+	}
+
+
 
 
 	/**
@@ -66,6 +82,8 @@ public class RJ_AftershockModel_Generic extends RJ_AftershockModel {
 		this(magMain, params.get_aValueMean(), params.get_aValueSigma(magMain), -4.5, -0.5, 
 				params.get_bValue(), params.get_pValue(), params.get_cValue());
 	}
+
+
 	
 	
 	/**
@@ -82,106 +100,208 @@ public class RJ_AftershockModel_Generic extends RJ_AftershockModel {
 	public RJ_AftershockModel_Generic(double magMain, double mean_a, double sigma_a, double min_a, double max_a,
 											double b, double p, double c) {
 		
-		this.magMain= magMain;
-		this.b=b;
+		this.magMain = magMain;
+		this.b = b;
 
-		this.mean_a=mean_a;
-		this.sigma_a=sigma_a;
+		this.mean_a = mean_a;
+		this.sigma_a = sigma_a;
 
 		if(min_a>max_a) {
-			throw new RuntimeException("Problem: aValueMin > aValueMax");
+			throw new RuntimeException("RJ_AftershockModel_Generic: aValueMin > aValueMax");
 		}
-		if(sigma_a<=0){
-			throw new RuntimeException("Problem: sigma_a must be greater than 0");
+		if(sigma_a<=0.0){
+			throw new RuntimeException("RJ_AftershockModel_Generic: sigma_a must be greater than 0");
 		}
 		
 		this.delta_a=0.01;	// this is so one of the discrete values is within 0.005 of mean_a
 		this.min_a = ((double)Math.round(min_a*100))/100d;	// round to nearest 100th value
 		this.max_a = ((double)Math.round(max_a*100))/100d;	// round to nearest 100th value
 		this.num_a = (int)Math.round((max_a-min_a)/delta_a) + 1;
-		EvenlyDiscretizedFunc aValueFunc = new EvenlyDiscretizedFunc(min_a, max_a, num_a);
-		for(int i=0;i<aValueFunc.size();i++) {
-			double wt = Math.exp(-(mean_a-aValueFunc.getX(i))*(mean_a-aValueFunc.getX(i))/(2*sigma_a*sigma_a));
-			aValueFunc.set(i,wt);
-		}
-		
-		setArrayAndMaxLikelyValuesFrom_aValueFunc(aValueFunc, b, p, c);
+
+		set_fixed_p(p);
+		set_fixed_c(c);
+
+		apc_build();
 
 		if(D) {
-			System.out.println("getMaxLikelihood_a()="+getMaxLikelihood_a()+"\tmean_a="+mean_a+"\tratio="+(float)(mean_a/getMaxLikelihood_a()));
+			System.out.println(String.format("mean_a=%.4g  sigma_a=%.4g",
+				mean_a, sigma_a));
 		}
-		
-		
 	}
 
-    public RJ_AftershockModel_Generic() {
 
+
+
+	/**
+	 * This default constructor creates an empty model.
+	 * This is intended for use in database retrieval.
+	 */
+    public RJ_AftershockModel_Generic() {
+		// When retrieving from database, remain quiet by default
+		D = false;
     }
 
 
-    public static void main(String[] args) {
-		
-//		double magMain=7.8;
-//		double mean_a=-2.47;
-//		double sigma_a=0.5;
-//		double min_a = mean_a-3.0*sigma_a;
-//		double max_a = mean_a+3.0*sigma_a;
-//		double b=1.0;
-//		double p=0.88;
-//		double c=0.018;
-//		
-//		RJ_AftershockModel_Generic gen = new RJ_AftershockModel_Generic(magMain,mean_a,sigma_a,min_a,max_a,b,p,c);
-		
-		GenericRJ_ParametersFetch fetch = new GenericRJ_ParametersFetch();
-		Location loc = new Location(33.0, -120, 6.0);
-		RJ_AftershockModel_Generic gen = new RJ_AftershockModel_Generic(7d,fetch.get(loc));
-				
-		
-		EvenlyDiscretizedFunc lowFract = gen.getCumNumMFD_Fractile(0.025, 5.0, 8.0, 31, 0d, 7d);
-		System.out.println("2.5%: "+lowFract.getX(0)+"\t"+lowFract.getY(0));
-		EvenlyDiscretizedFunc hiFract = gen.getCumNumMFD_Fractile(0.975, 5.0, 8.0, 31, 0d, 7d);
-		System.out.println("97.5%: "+hiFract.getX(0)+"\t"+hiFract.getY(0));
-		
-		double[] fractArray = {0.025, 0.975};
-		EvenlyDiscretizedFunc[] fractalWithAleatoryMFDArray = gen.getCumNumMFD_FractileWithAleatoryVariability(fractArray, 5.0, 8.0, 31, 0d, 7d);
-		System.out.println("2.5% With Aleatory: "+fractalWithAleatoryMFDArray[0].getX(0)+"\t"+fractalWithAleatoryMFDArray[0].getY(0));
-		System.out.println("97.5% With Aleatory: "+fractalWithAleatoryMFDArray[1].getX(0)+"\t"+fractalWithAleatoryMFDArray[1].getY(0));
 
-//		double mean = gen.getModalNumEvents(5.0, 0d, 7d);
-//		System.out.println("Mode: "+mean);
+
+	/**
+	 * Build the apc_likelihood matrix, that gives the probability distribution of (a,p,c).
+	 */
+    public void apc_build() {
+
+		// Construct the Gaussian distribution
+		
+		apc_likelihood = new double[num_a][num_p][num_c];
+		for (int aIndex = 0; aIndex < num_a; aIndex++) {
+			double wt = Math.exp(-(mean_a - get_a(aIndex))*(mean_a - get_a(aIndex))/(2.0*sigma_a*sigma_a));
+			apc_likelihood[aIndex][0][0] = wt;
+		}
+
+		// Complete the likelihood setup
+
+		apcFinish (false);
+
+		return;
+    }
+
+
+
+
+    public static void main(String[] args) {
+
+		// There needs to be at least one argument, which is the subcommand
+
+		if (args.length < 1) {
+			System.err.println ("RJ_AftershockModel_Generic : Missing subcommand");
+			return;
+		}
+
+
+		// Subcommand : Test #1
+		// Command format:
+		//  test1
+		// This is the pre-existing test for the class.
+
+		if (args[0].equalsIgnoreCase ("test1")) {
+
+			// No additional arguments
+
+			if (args.length != 1) {
+				System.err.println ("RJ_AftershockModel_Generic : Invalid 'test1' subcommand");
+				return;
+			}
+
+			// Run the test
+		
+//			double magMain=7.8;
+//			double mean_a=-2.47;
+//			double sigma_a=0.5;
+//			double min_a = mean_a-3.0*sigma_a;
+//			double max_a = mean_a+3.0*sigma_a;
+//			double b=1.0;
+//			double p=0.88;
+//			double c=0.018;
 //		
-//		gen.getCumNumFractileWithAleatory(0.025, 5, 0, 7);
-//		gen.getCumNumFractileWithAleatory(0.975, 5, 0, 7);
-//		System.exit(-1);
+//			RJ_AftershockModel_Generic gen = new RJ_AftershockModel_Generic(magMain,mean_a,sigma_a,min_a,max_a,b,p,c);
+		
+			GenericRJ_ParametersFetch fetch = new GenericRJ_ParametersFetch();
+			Location loc = new Location(33.0, -120, 6.0);
+			RJ_AftershockModel_Generic gen = new RJ_AftershockModel_Generic(7d,fetch.get(loc));
+				
+		
+			EvenlyDiscretizedFunc lowFract = gen.getCumNumMFD_Fractile(0.025, 5.0, 8.0, 31, 0d, 7d);
+			System.out.println("2.5%: "+lowFract.getX(0)+"\t"+lowFract.getY(0));
+			EvenlyDiscretizedFunc hiFract = gen.getCumNumMFD_Fractile(0.975, 5.0, 8.0, 31, 0d, 7d);
+			System.out.println("97.5%: "+hiFract.getX(0)+"\t"+hiFract.getY(0));
+		
+			double[] fractArray = {0.025, 0.975};
+			EvenlyDiscretizedFunc[] fractalWithAleatoryMFDArray = gen.getCumNumMFD_FractileWithAleatoryVariability(fractArray, 5.0, 8.0, 31, 0d, 7d);
+			System.out.println("2.5% With Aleatory: "+fractalWithAleatoryMFDArray[0].getX(0)+"\t"+fractalWithAleatoryMFDArray[0].getY(0));
+			System.out.println("97.5% With Aleatory: "+fractalWithAleatoryMFDArray[1].getX(0)+"\t"+fractalWithAleatoryMFDArray[1].getY(0));
+
+//			double mean = gen.getModalNumEvents(5.0, 0d, 7d);
+//			System.out.println("Mode: "+mean);
+//		
+//			gen.getCumNumFractileWithAleatory(0.025, 5, 0, 7);
+//			gen.getCumNumFractileWithAleatory(0.975, 5, 0, 7);
+//			System.exit(-1);
 		
 				
-//		RJ_AftershockModel_Generic gen = new RJ_AftershockModel_Generic(7.0, -2.5, 1.0, -4.5, -0.5, 1.0, 1.12, 0.018);
-//		System.out.println("gen.getPDF_a():\n"+gen.getPDF_a());
+//			RJ_AftershockModel_Generic gen = new RJ_AftershockModel_Generic(7.0, -2.5, 1.0, -4.5, -0.5, 1.0, 1.12, 0.018);
+//			System.out.println("gen.getPDF_a():\n"+gen.getPDF_a());
 		
-//		ArrayList<HistogramFunction> funcList = new ArrayList<HistogramFunction>();
-//		funcList.add(gen.getPDF_a());
-//		ArrayList<PlotCurveCharacterstics> curveCharList = new ArrayList<PlotCurveCharacterstics>();
-//		curveCharList.add(new PlotCurveCharacterstics(PlotLineType.HISTOGRAM, 2f, Color.BLACK));
-//		GraphWindow aValueDistGraph = new GraphWindow(funcList, "PDF"); 
-//		aValueDistGraph.setX_AxisLabel("a-value");
-//		aValueDistGraph.setY_AxisLabel("Density");
+//			ArrayList<HistogramFunction> funcList = new ArrayList<HistogramFunction>();
+//			funcList.add(gen.getPDF_a());
+//			ArrayList<PlotCurveCharacterstics> curveCharList = new ArrayList<PlotCurveCharacterstics>();
+//			curveCharList.add(new PlotCurveCharacterstics(PlotLineType.HISTOGRAM, 2f, Color.BLACK));
+//			GraphWindow aValueDistGraph = new GraphWindow(funcList, "PDF"); 
+//			aValueDistGraph.setX_AxisLabel("a-value");
+//			aValueDistGraph.setY_AxisLabel("Density");
 //		
-//		ArrayList<ArbitrarilyDiscretizedFunc> funcList2 = new ArrayList<ArbitrarilyDiscretizedFunc>();
-//		funcList2.add(gen.computeNumMag5_DistributionFunc(0, 7).getCumDist());
-//		GraphWindow numM5_Dist = new GraphWindow(funcList2, "PDF"); 
-//		numM5_Dist.setX_AxisLabel("Num M>=5");
-//		numM5_Dist.setY_AxisLabel("Density");
+//			ArrayList<ArbitrarilyDiscretizedFunc> funcList2 = new ArrayList<ArbitrarilyDiscretizedFunc>();
+//			funcList2.add(gen.computeNumMag5_DistributionFunc(0, 7).getCumDist());
+//			GraphWindow numM5_Dist = new GraphWindow(funcList2, "PDF"); 
+//			numM5_Dist.setX_AxisLabel("Num M>=5");
+//			numM5_Dist.setY_AxisLabel("Density");
 //		
-//		ArrayList<EvenlyDiscretizedFunc> funcList3 = new ArrayList<EvenlyDiscretizedFunc>();
-//		funcList3.add(gen.getModalCumNumMFD(4.05, 8.95, 50, 0d, 7d));
-//		funcList3.add(gen.getMeanCumNumMFD(4.05, 8.95, 50, 0d, 7d));
-//		funcList3.add(gen.getCumNumMFD_Fractile(0.025, 4.05, 8.95, 50, 0d, 7d));
-//		funcList3.add(gen.getCumNumMFD_Fractile(0.5, 4.05, 8.95, 50, 0d, 7d));
-//		funcList3.add(gen.getCumNumMFD_Fractile(0.975, 4.05, 8.95, 50, 0d, 7d));
-//		GraphWindow mfdGraph = new GraphWindow(funcList3, "MFDs"); 
-//		mfdGraph.setX_AxisLabel("Magnitude");
-//		mfdGraph.setY_AxisLabel("Num≥M");
-//		mfdGraph.setYLog(true);
+//			ArrayList<EvenlyDiscretizedFunc> funcList3 = new ArrayList<EvenlyDiscretizedFunc>();
+//			funcList3.add(gen.getModalCumNumMFD(4.05, 8.95, 50, 0d, 7d));
+//			funcList3.add(gen.getMeanCumNumMFD(4.05, 8.95, 50, 0d, 7d));
+//			funcList3.add(gen.getCumNumMFD_Fractile(0.025, 4.05, 8.95, 50, 0d, 7d));
+//			funcList3.add(gen.getCumNumMFD_Fractile(0.5, 4.05, 8.95, 50, 0d, 7d));
+//			funcList3.add(gen.getCumNumMFD_Fractile(0.975, 4.05, 8.95, 50, 0d, 7d));
+//			GraphWindow mfdGraph = new GraphWindow(funcList3, "MFDs"); 
+//			mfdGraph.setX_AxisLabel("Magnitude");
+//			mfdGraph.setY_AxisLabel("Num>=M");
+//			mfdGraph.setYLog(true);
+
+			return;
+		}
+
+
+		// Subcommand : Test #2
+		// Command format:
+		//  test2
+		// Same as test #1 but with apc_tail_fraction forced to zero, and testing rebuild.
+
+		if (args[0].equalsIgnoreCase ("test2")) {
+
+			// No additional arguments
+
+			if (args.length != 1) {
+				System.err.println ("RJ_AftershockModel_Generic : Invalid 'test2' subcommand");
+				return;
+			}
+
+			// Run the test
+		
+			GenericRJ_ParametersFetch fetch = new GenericRJ_ParametersFetch();
+			Location loc = new Location(33.0, -120, 6.0);
+			RJ_AftershockModel_Generic gen = new RJ_AftershockModel_Generic(7d,fetch.get(loc));
+				
+			gen.apc_tail_fraction = 0.0;
+			gen.apc_build();
+		
+			EvenlyDiscretizedFunc lowFract = gen.getCumNumMFD_Fractile(0.025, 5.0, 8.0, 31, 0d, 7d);
+			System.out.println("2.5%: "+lowFract.getX(0)+"\t"+lowFract.getY(0));
+			EvenlyDiscretizedFunc hiFract = gen.getCumNumMFD_Fractile(0.975, 5.0, 8.0, 31, 0d, 7d);
+			System.out.println("97.5%: "+hiFract.getX(0)+"\t"+hiFract.getY(0));
+		
+			double[] fractArray = {0.025, 0.975};
+			EvenlyDiscretizedFunc[] fractalWithAleatoryMFDArray = gen.getCumNumMFD_FractileWithAleatoryVariability(fractArray, 5.0, 8.0, 31, 0d, 7d);
+			System.out.println("2.5% With Aleatory: "+fractalWithAleatoryMFDArray[0].getX(0)+"\t"+fractalWithAleatoryMFDArray[0].getY(0));
+			System.out.println("97.5% With Aleatory: "+fractalWithAleatoryMFDArray[1].getX(0)+"\t"+fractalWithAleatoryMFDArray[1].getY(0));
+
+			return;
+		}
+
+
+
+
+		// Unrecognized subcommand.
+
+		System.err.println ("RJ_AftershockModel_Generic : Unrecognized subcommand : " + args[0]);
+		return;
 	
 	}
 

--- a/src/scratch/aftershockStatistics/USGS_AftershockForecast.java
+++ b/src/scratch/aftershockStatistics/USGS_AftershockForecast.java
@@ -201,14 +201,7 @@ public class USGS_AftershockForecast {
 
 		// MODEL
 		JSONObject modelJSON = new JSONObject();
-		String name = "Reasenberg-Jones (1989, 1994) aftershock model";
-		if (model instanceof RJ_AftershockModel_Bayesian)
-			name += " (Bayesian Combination)";
-		else if (model instanceof RJ_AftershockModel_Generic)
-			name += " (Generic)";
-		else if (model instanceof RJ_AftershockModel_SequenceSpecific)
-			name += " (Sequence Specific)";
-		modelJSON.put("name", name);
+		modelJSON.put("name", model.getModelName());
 		modelJSON.put("reference", "#url");
 		JSONObject modelParams = new JSONObject();
 		// return AftershockStatsCalc.getExpectedNumEvents(getMaxLikelihood_a(), b, magMain, magMin, getMaxLikelihood_p(), getMaxLikelihood_c(), tMinDays, tMaxDays);

--- a/src/scratch/aftershockStatistics/cmu/JobsListener.java
+++ b/src/scratch/aftershockStatistics/cmu/JobsListener.java
@@ -104,11 +104,11 @@ public class JobsListener implements MessageListener {
             double h = job.h;
             //double mCat = 4.5;
             double mCat = job.magCat;
-            //double b = genericParams.get_bValue();
-            double b = job.b;
-            if (b < 0){
-                b = genericParams.get_bValue();
-            }
+            double b = genericParams.get_bValue();
+            //double b = job.b;
+            //if (b < 0){
+            //    b = genericParams.get_bValue();
+            //}
             double p = genericParams.get_pValue();
             double c = genericParams.get_cValue();
             double aMin = job.minA;


### PR DESCRIPTION
This is a revision of the Reasenberg-Jones aftershock models.  Highlights:

Add extensive documentation to the R&J model classes, so it is clear what they do.

Fix bugs, precision issues, and performance issues.  Improve the design of this class hierarchy; consolidate and clean up code.

Replace the buggy adaptive quadrature routine with a correct one.  Auto-switch to analytic integration when possible.

Add a routine to generate simulated aftershock sequences, according to R&J statistics with Page et al. magnitude of completeness.  Use it to test the sequence-specific model.

Clip the tail of the epistemic probability distribution so that time is not spent doing calculations that contribute negligably to the final result.

Fix issue which caused the automatic system to attempt forming Bayesian combinations of incompatible models.